### PR TITLE
Ability to inject custom hook just before request and just after response

### DIFF
--- a/lib/http.rb
+++ b/lib/http.rb
@@ -4,6 +4,7 @@ require 'http/client'
 require 'http/mime_type'
 require 'http/parameters'
 require 'http/response'
+require 'http/event_callback'
 
 # THIS IS ENTIRELY TEMPORARY, I ASSURE YOU
 require 'net/https'

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -55,7 +55,21 @@ module Http
         headers = default_headers
       end
 
-      Client.new(uri).request verb, options.merge(:headers => headers)
+      Client.new(uri).request verb, options.merge(:headers => headers, :callbacks => event_callbacks)
+    end
+
+    # Make a request invoking the given event callbacks
+    def on(event, &block)
+      unless [:request, :response].include?(event)
+        raise ArgumentError, "only :request and :response are valid events"
+      end
+      unless block_given?
+        raise ArgumentError, "no block specified for #{event} event"
+      end
+      unless block.arity == 1
+        raise ArgumentError, "block must accept only one argument" 
+      end
+      EventCallback.new event, event_callbacks, &block
     end
 
     # Make a request with the given headers
@@ -81,6 +95,14 @@ module Http
 
     def default_headers=(headers)
       @default_headers = headers
+    end
+
+    def event_callbacks
+      @event_callbacks ||= {}
+    end
+
+    def event_callbacks=(callbacks)
+      @event_callbacks = callbacks
     end
   end
 end

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -77,7 +77,12 @@ module Http
       request = request_class.new(@uri.request_uri, headers)
       request.set_form_data(options[:form]) if options[:form]
 
+      callbacks = options[:callbacks] || {}
+      (callbacks[:request] || []).each{|c| c.invoke(request)}
+
       net_http_response = http.request(request)
+
+      (callbacks[:response] || []).each{|c| c.invoke(net_http_response)}
 
       response = Http::Response.new
       net_http_response.each_header do |header, value|

--- a/lib/http/event_callback.rb
+++ b/lib/http/event_callback.rb
@@ -1,0 +1,16 @@
+module Http
+  class EventCallback
+    include Chainable
+
+    def initialize(event, callbacks, &block)
+      self.event_callbacks = callbacks
+      @block = block
+      callbacks[event] ||= []
+      callbacks[event] << self
+    end
+
+    def invoke(request_or_response)
+      @block.call(request_or_response)
+    end
+  end
+end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -16,6 +16,20 @@ describe Http do
         response['json'].should be_true
       end
     end
+
+    context "with callbacks" do
+      it "should be easy" do
+        request = nil
+        response = nil
+
+        Http.on(:request)  {|r| request = r}
+            .on(:response)  {|r| response = r}
+            .get test_endpoint
+
+        request.should_not be_nil
+        response.should_not be_nil
+      end
+    end
   end
 
   context "posting to resources" do


### PR DESCRIPTION
Not sure how useful this would be to a wider audience, but I wanted some visibility into what was going out onto the wire and what was coming back.

Instead of hacking ugly log statements into Http::Client, and checking if a verbose option was supplied, I thought something a tad more general would be better, so this commit adds the ability to register a block to be invoked just before and just after the request is sent and response is received.

The block is passed request and response objects (currently the Net::HTTP ones, as they give me the most info).

Example usage:

``` ruby
def dump_request(request)
  puts "> #{request.method} #{request.path}"
  request.each_header do |header, value|
    puts "> #{header}: #{value}"
  end
end

def dump_response(response)
  puts
  puts "< HTTP/#{response.http_version} #{response.code} #{response.msg}"
  response.each_header do |header, value|
    puts "< #{header}: #{value}"
  end
  puts
end

def login(uri, access_code, password)
  form = {ac: access_code, pw: password}
  Http.with('User-Agent' => USER_AGENT)
      .on(:request) {|req| dump_request(req)}
      .on(:response) {|resp| dump_response(resp)}
      .post(uri.to_s, :form => form)
end
```

Cheers for the awesome lib.
