### PR TITLE
HTTP proxy support?

### DIFF
--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -32,6 +32,13 @@ describe Http do
         response.should be_a Http::Response
       end
     end
+    
+    context "with http proxy" do
+      it "should proxy the request" do
+        response = Http.via("127.0.0.1","8080").get(test_endpoint)
+        response.should == "passed :)"
+      end
+    end
   end
 
   context "posting to resources" do


### PR DESCRIPTION
Are HTTP proxies within the scope of the project? I really like the direction the library is heading and use a lot of proxies, so I figured I'd ask w/ a barebones pull request.

I went with `#via` to keep the request chain succinct, but I think `#through` might be more expressive.

Integrating proxies with both Net::HTTP and Curb is reasonably straightforward:
- [Net::HTTP proxy methods](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/net/http/rdoc/Net/HTTP.html#method-i-proxy-3F)
- [Curb proxy methods](http://curb.rubyforge.org/classes/Curl/Easy.html#M000055)
