### PR TITLE
Basic HTTP Proxy Implementation [Reopens #8]

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -54,6 +54,22 @@ module Http
     def on(event, &block)
       branch default_options.with_callback(event, block)
     end
+    
+    # Make a request through an HTTP proxy
+    def via(*proxy)
+      proxy_hash = {}    
+      proxy_hash[:proxy_address] = proxy[0] if proxy[0].is_a? String
+      proxy_hash[:proxy_port]    = proxy[1] if proxy[1].is_a? Integer
+      proxy_hash[:proxy_username]= proxy[2] if proxy[2].is_a? String
+      proxy_hash[:proxy_password]= proxy[3] if proxy[3].is_a? String
+      
+      if proxy_hash.keys.size >=2
+        with proxy_hash
+      else
+        raise ArgumentError, "invalid HTTP proxy: #{proxy_hash}"
+      end
+    end
+    alias_method :through, :via
 
     # Make a request with the given headers
     def with_headers(headers)
@@ -105,6 +121,5 @@ module Http
     def branch(options)
       Client.new(options)
     end
-
   end
 end

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -17,12 +17,14 @@ module Http
 
       @headers = {}
       headers.each do |name, value|
-        name = name.to_s
-        key = name[CANONICAL_HEADER]
-        key ||= Http.canonicalize_header(name)
-        @headers[key] = value
-      end
-
+        unless name =~ /proxy/
+          name = name.to_s
+          key = name[CANONICAL_HEADER]
+          key ||= Http.canonicalize_header(name)
+          @headers[key] = value
+        end
+      end      
+      
       @body, @version = body, version
     end
 
@@ -34,7 +36,9 @@ module Http
     # Create a Net::HTTP request from this request
     def to_net_http_request
       request_class = Net::HTTP.const_get(@method.to_s.capitalize)
+
       request = request_class.new(@uri.request_uri, @headers)
+      
       request.body = @body
       request
     end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -31,13 +31,26 @@ describe Http do
         Http.on(:response) {|r| response = r}.get test_endpoint
         response.should be_a Http::Response
       end
+    end    
+  end
+  
+  context "with http proxy address and port" do
+    it "should proxy the request" do
+      response = Http.via("127.0.0.1", 65432).get test_endpoint
+      response.should match(/<!doctype html>/)
     end
-    
-    context "with http proxy" do
-      it "should proxy the request" do
-        response = Http.via("127.0.0.1","8080").get(test_endpoint)
-        response.should == "passed :)"
-      end
+  end
+  
+  context "with http proxy address, port username and password" do
+    it "should proxy the request" do
+      response = Http.via("127.0.0.1", 65432, "username", "password").get test_endpoint
+      response.should match(/<!doctype html>/)
+    end
+  end
+  
+  context "without proxy port" do
+    it "should raise an argument error" do
+      expect { Http.via("127.0.0.1") }.to raise_error ArgumentError
     end
   end
 


### PR DESCRIPTION
`Http#via` and `Http#through` are the primary methods. They basically transform an array into a dictionary of pieces of proxy software `{proxy_address: addr, proxy_port: port, etc}. Specs need work, but oughta stop us from breaking the functionality.

Usage:

```
Http.via("127.0.0.1", 8080, "username", "password").get("http://git.io/")
```
