### PR TITLE
unsure but this could solve #22

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -84,7 +84,7 @@ module HTTP
         if !parser.finished? || (@body_remaining && @body_remaining > 0)
           chunk = parser.chunk || begin
             parser << socket.readpartial(BUFFER_SIZE)
-            parser.chunk || ""
+            parser.chunk
           end
 
           @body_remaining -= chunk.length if @body_remaining


### PR DESCRIPTION
I am sorry I don't totally understand the initial code here but the correction both does not seem to break any tests and for the failing example "https://btc-e.com/api/2/btc_usd/depth" gives the correct result. 

This is some hard to read code with the double double pipes I am not sure I understand all the conditions here. 

Anyway in this specific example there was no Content-Length header so @body_remaining  is nil while Transfer-Encoding: chunked

But I really can't be sure I am not introducing some breakage here. I just don't really know what tests I can add.
