### PR TITLE
Use json gem instead of yanked rubysl-json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 group :test do
   gem 'backports'
   gem 'coveralls', :require => false
-  gem 'json', '>= 1.8.1', :platforms => [:jruby, :ruby_18, :ruby_19]
+  gem 'json', '>= 1.8.1'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'rspec', '>= 2.14'
   gem 'rubocop', '>= 0.16', :platforms => [:ruby_19, :ruby_20, :ruby_21]
@@ -31,7 +31,6 @@ platforms :rbx do
   gem 'racc'
   gem 'rubinius-coverage', '~> 2.0'
   gem 'rubysl', '~> 2.0'
-  gem 'rubysl-json', '~> 2.0'
 end
 
 # Specify your gem's dependencies in http.gemspec


### PR DESCRIPTION
`rubysl-json` was ynaked in favor of lots of existing JSON gems.
