### PR TITLE
Fix following relative URIs in Location

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -27,6 +27,7 @@ module HTTP
     def request(verb, uri, options = {})
       opts = @default_options.merge(options)
       host = URI.parse(uri).host
+      scheme = URI.parse(uri).scheme
       opts.headers['Host'] = host
       headers = opts.headers
       proxy = opts.proxy
@@ -39,9 +40,10 @@ module HTTP
         code = 302
         while code == 302 || code == 301
           # if the uri isn't fully formed complete it
-          uri = "#{verb}://#{host}#{uri}" unless uri.match(/\./)
-          host = URI.parse(uri).host
-          opts.headers['Host'] = host
+          uri = URI.parse(uri.to_s)
+          uri.scheme ||= scheme
+          uri.host   ||= host
+          opts.headers['Host'] = uri.host
           method_body = body(opts, headers)
           request = HTTP::Request.new(verb, uri, headers, proxy, method_body)
           response = perform request, opts

--- a/spec/http/client_spec.rb
+++ b/spec/http/client_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe HTTP::Client do
+  StubbedClient = Class.new(HTTP::Client) do
+    def initialize(options = {})
+      @stubs = options.delete(:stubs) || {}
+      super(options)
+    end
+
+    def perform(request, options)
+      @stubs[request.uri.to_s] || super(request, options)
+    end
+  end
+
+
+  def redirect_response(location, status = 302)
+    HTTP::Response.new(status, '1.1', { 'Location' => location }, '')
+  end
+
+
+  def simple_response(body, status = 200)
+    HTTP::Response.new(status, '1.1', {}, body)
+  end
+
+
+  describe 'following redirects' do
+    it 'prepends previous request uri scheme and host if needed' do
+      client = StubbedClient.new({ :follow => true, :stubs  => {
+        'http://example.com/'           => redirect_response('/index'),
+        'http://example.com/index'      => redirect_response('/index.html'),
+        'http://example.com/index.html' => simple_response('OK')
+      } })
+      expect(client.get('http://example.com/').response.body).to eq 'OK'
+    end
+  end
+end


### PR DESCRIPTION
Original code was not working with relative URIs at all,
at least due to `verb` is an HTTP verb, e.g. `:get`. Also,
original code was not handling relative URIs with extension.

Here's problematic redirect flows (that are now properly covered):
##### Redirect to relative URL with filename extension

```
> GET http://example.com
< HTTP/1.1 302
< Location: /index.html

> GET /index.html
```
##### Redirect to relative URL without filename extension

```
> GET http://example.com
< HTTP/1.1 302
< Location: /blog

> GET get://example.com/index
```
