### PR TITLE
Fail when URI given without scheme

### DIFF
--- a/spec/http/request_spec.rb
+++ b/spec/http/request_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe HTTP::Request do
+  it 'requires URI to have scheme part' do
+    expect { HTTP::Request.new(:get, 'example.com/') }
+      .to raise_error(HTTP::Request::UnsupportedSchemeError)
+  end
+
+  it "provides a #scheme accessor" do
+    request = HTTP::Request.new(:get, 'http://example.com/')
+    expect(request.scheme).to eq(:http)
+  end
+
   describe 'headers' do
     subject { HTTP::Request.new(:get, 'http://example.com/', :accept => 'text/html') }
 


### PR DESCRIPTION
This makes errors when invalid URI given less cryptic:

```
  % ruby -I ./lib -r http -e "HTTP.get 'example.com/'"
  /home/ixti/Projects/vidiq/http/lib/http/request.rb:65:in `initialize': unknown scheme:  (HTTP::Request::UnsupportedSchemeError)
    from /home/ixti/Projects/vidiq/http/lib/http/client.rb:37:in `new'
    from /home/ixti/Projects/vidiq/http/lib/http/client.rb:37:in `request'
    from /home/ixti/Projects/vidiq/http/lib/http/chainable.rb:50:in `request'
    from /home/ixti/Projects/vidiq/http/lib/http/chainable.rb:10:in `get'
```

versus previous behavior:

```
  % ruby -r http -e "HTTP.get 'example.com/'"
  /home/ixti/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/http-0.5.0/lib/http/client.rb:67:in `initialize': getaddrinfo: Name or service not known (SocketError)
    from /home/ixti/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/http-0.5.0/lib/http/client.rb:67:in `open'
    from /home/ixti/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/http-0.5.0/lib/http/client.rb:67:in `perform'
    from /home/ixti/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/http-0.5.0/lib/http/client.rb:58:in `request'
    from /home/ixti/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/http-0.5.0/lib/http/chainable.rb:50:in `request'
    from /home/ixti/.rbenv/versions/1.9.3-p484/lib/ruby/gems/1.9.1/gems/http-0.5.0/lib/http/chainable.rb:10:in `get'
    from -e:1:in `<main>'
```
