### PR TITLE
Remove FIXME of reason fetcher

### DIFF
--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -99,7 +99,6 @@ module HTTP
 
     # Obtain the 'Reason-Phrase' for the response
     def reason
-      # FIXME: should get the real reason phrase from the parser
       STATUS_CODES[@status]
     end
 


### PR DESCRIPTION
http_parser does not provides status reason (it actually skips it completely
while parsing).
