### PR TITLE
fixes (?) chunked reponse parsing

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -59,7 +59,7 @@ module HTTP
           fail StateError, "expected #{@body_remaining} more bytes of body"
         end
 
-        @body_remaining -= chunk.bytesize if chunk
+        @body_remaining -= chunk.bytesize if chunk && @body_remaining
         return chunk
       end
 


### PR DESCRIPTION
I am not sure why but I still had issues with chunked reponse and this fixed it for me.

As for my understanding: When no Content-Length header is present in the response @body_remaining is never initialized and trying to substract from nil does not work that well...
