### PR TITLE
explicitly close socket when finished

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -128,7 +128,10 @@ module HTTP
     # Callback for when we've reached the end of a response
     def finish_response
       # TODO: keep-alive support
-      @socket = nil
+      if @socket
+        @socket.close()
+        @socket = nil
+      end
     end
   end
 end


### PR DESCRIPTION
All my connections stayed open for some reason, explicitly closing them before forgetting the reference fixed the issue.
