### PR TITLE
Consolidate errors unders HTTP namespace

### DIFF
--- a/lib/http.rb
+++ b/lib/http.rb
@@ -1,5 +1,6 @@
 require 'http/parser'
 
+require 'http/errors'
 require 'http/chainable'
 require 'http/client'
 require 'http/options'
@@ -12,9 +13,6 @@ require 'http/uri_backport' if RUBY_VERSION < '1.9.0'
 
 # HTTP should be easy
 module HTTP
-  # Request to do something when we're in the wrong state
-  class StateError < StandardError; end
-
   extend Chainable
 
   class << self

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -61,7 +61,7 @@ module HTTP
       if [2, 4].include?(proxy_hash.keys.size)
         branch default_options.with_proxy(proxy_hash)
       else
-        fail(ArgumentError, "invalid HTTP proxy: #{proxy_hash}")
+        fail(RequestError, "invalid HTTP proxy: #{proxy_hash}")
       end
     end
     alias_method :through, :via

--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -1,0 +1,13 @@
+module HTTP
+  # Generic error
+  class Error < StandardError; end
+
+  # Generic Request error
+  class RequestError < Error; end
+
+  # Generic Response error
+  class ResponseError < Error; end
+
+  # Request to do something when we're in the wrong state
+  class StateError < ResponseError; end
+end

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -145,7 +145,7 @@ module HTTP
   private
 
     def argument_error!(message)
-      fail(ArgumentError, message, caller[1..-1])
+      fail(Error, message, caller[1..-1])
     end
   end
 end

--- a/lib/http/redirector.rb
+++ b/lib/http/redirector.rb
@@ -1,7 +1,7 @@
 module HTTP
   class Redirector
     # Notifies that we reached max allowed redirect hops
-    class TooManyRedirectsError < RuntimeError; end
+    class TooManyRedirectsError < ResponseError; end
 
     # Notifies that following redirects got into an endless loop
     class EndlessRedirectError < TooManyRedirectsError; end

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -8,10 +8,10 @@ module HTTP
     include HTTP::Header
 
     # The method given was not understood
-    class UnsupportedMethodError < ArgumentError; end
+    class UnsupportedMethodError < RequestError; end
 
     # The scheme of given URI was not understood
-    class UnsupportedSchemeError < ArgumentError; end
+    class UnsupportedSchemeError < RequestError; end
 
     # Prefix for relative URLs
     PREFIX_RE = %r{^[^:]+://[^/]+}

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -6,7 +6,7 @@ module HTTP
 
       def initialize(socket, body, headers, headerstart) # rubocop:disable ParameterLists
         @body           = body
-        fail(ArgumentError, 'body of wrong type') unless valid_body_type
+        fail(RequestError, 'body of wrong type') unless valid_body_type
         @socket         = socket
         @headers        = headers
         @request_header = [headerstart]
@@ -41,7 +41,7 @@ module HTTP
           if encoding == 'chunked'
             @request_header << 'Transfer-Encoding: chunked'
           else
-            fail(ArgumentError, 'invalid transfer encoding')
+            fail(RequestError, 'invalid transfer encoding')
           end
         end
       end

--- a/spec/http/options/headers_spec.rb
+++ b/spec/http/options/headers_spec.rb
@@ -23,7 +23,7 @@ describe HTTP::Options, 'headers' do
   it 'recognizes invalid headers' do
     expect do
       opts.with_headers(self)
-    end.to raise_error(ArgumentError)
+    end.to raise_error(HTTP::Error)
   end
 
 end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -53,7 +53,7 @@ describe HTTP do
 
   context 'without proxy port' do
     it 'should raise an argument error' do
-      expect { HTTP.via('127.0.0.1') }.to raise_error ArgumentError
+      expect { HTTP.via('127.0.0.1') }.to raise_error HTTP::RequestError
     end
   end
 


### PR DESCRIPTION
General idea is to allow catch HTTP Gem errors in a consolidated way:

``` ruby
class MyFetcher
  def fetch
    # ...
  rescue HTTP::Error
    # ...
  end
end
```

/cc @sferik @tarcieri 
