### PR TITLE
Add support for HTTP.auth chainable

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -75,9 +75,9 @@ module HTTP
       case type
       when :basic
         encoded = Base64.encode64("#{options[:user]}:#{options[:pass]}")
-        with_headers "Authorization" => "Basic #{encoded}"
+        with_headers 'Authorization' => "Basic #{encoded}"
       when :bearer
-        with_headers "Authorization" => "Bearer #{Base64.encode64(options)}"
+        with_headers 'Authorization' => "Bearer #{Base64.encode64(options)}"
       end
     end
 


### PR DESCRIPTION
As per https://github.com/tarcieri/http/issues/84, allows for shortcutting HTTP Basic Auth and OAuth 2.0 Bearer Auth requests.

Examples:

``` ruby
HTTP
  .auth(:basic, user: "admin", pass: "admin")
  .get("http://website.com/path/to/restricted/area")
```

``` ruby
HTTP
  .auth(:bearer, "[ACCESS TOKEN]")
  .get("https://website.com/path/to/restricted/area")
```

I'm not super-up-to-date on how bearer requests in OAuth work, and whether or not they need to be Base64 encoded. [Twitter](https://dev.twitter.com/docs/auth/application-only-auth) seems to think so, but [the spec](http://tools.ietf.org/html/rfc6750) doesn't seem to mention it anywhere.

Might be good to have a form like this?

``` ruby
HTTP.auth(:bearer, token: "[TOKEN]", encode: true)
```
