### PR TITLE
Fix for params test in HTTP get

### DIFF
--- a/spec/support/example_server.rb
+++ b/spec/support/example_server.rb
@@ -17,7 +17,7 @@ class ExampleService < WEBrick::HTTPServlet::AbstractServlet
         response.body   = '<!doctype html>'
       end
     when '/params'
-      if request.query_string = 'foo=bar'
+      if request.query_string == 'foo=bar'
         response.status = 200
         response.body     = 'Params!'
       end


### PR DESCRIPTION
Tiny change, but this test wasn't actually testing that the params passed in were being used.
