### PR TITLE
check for empty params

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -32,7 +32,7 @@ module HTTP
       proxy = opts.proxy
 
       method_body = body(opts, headers)
-      if opts.params
+      if opts.params && !opts.params.empty?
         uri="#{uri}?#{URI.encode_www_form(opts.params)}"
       end
 


### PR DESCRIPTION
Am writing a etcd client, the server throws a http 5*\* error when a questionmark is added without params.

So this is needed.
