### PR TITLE
Fix bug in normalizing get params

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -144,7 +144,7 @@ module HTTP
       uri = URI(uri) unless uri.is_a?(URI)
       if uri.query
         extracted_params_from_uri = Hash[URI.decode_www_form(uri.query)]
-        opts = opts.with_params(extracted_params_from_uri.merge(opts.params))
+        opts = opts.with_params(extracted_params_from_uri.merge(opts.params || {}))
         uri.query = nil
       end
       [uri, opts]

--- a/spec/http/client_spec.rb
+++ b/spec/http/client_spec.rb
@@ -70,6 +70,17 @@ describe HTTP::Client do
   end
 
   describe 'parsing params' do
+    it 'accepts params within the provided URL' do
+      client = HTTP::Client.new
+      allow(client).to receive(:perform)
+      expect(HTTP::Request).to receive(:new) do |_, uri|
+        params = CGI.parse(URI(uri).query)
+        expect(params).to eq('foo' => ['bar'])
+      end
+
+      client.get('http://example.com/?foo=bar')
+    end
+
     it 'combines GET params from the URI with the passed in params' do
       client = HTTP::Client.new
       allow(client).to receive(:perform)


### PR DESCRIPTION
This fixes a bug I introduced in https://github.com/tarcieri/http/pull/90 . If you call HTTP.get('http://example.com/?foo=bar'), that was returning an error because the :params option was nil and I was attempting to merge it into the extracted params hash.
