### PR TITLE
Fix Request#redirect

### DIFF
--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -77,8 +77,8 @@ module HTTP
     # Returns new Request with updated uri
     def redirect(uri)
       uri = "#{@uri.to_s[PREFIX_RE]}#{uri}" unless uri.to_s[PREFIX_RE]
-      req = self.class.new(verb, uri, headers, body, version)
-      req.headers['Host'] = req.uri.host
+      req = self.class.new(verb, uri, headers, proxy, body, version)
+      req.headers.merge!('Host' => req.uri.host)
       req
     end
 

--- a/spec/http/request_spec.rb
+++ b/spec/http/request_spec.rb
@@ -41,4 +41,19 @@ describe HTTP::Request do
       expect(subject.__method__(:verb)).to be_a(Method)
     end
   end
+
+  describe 'redirect' do
+    subject {
+      HTTP::Request.new(:post, 'http://example.com/',
+        { :accept => 'text/html' }, {}, 'test')
+    }
+
+    it 'returns a new request to the new uri' do
+      redirected = subject.redirect('http://example.com/redirect')
+      expect(redirected.uri.to_s).to eq('http://example.com/redirect')
+      expect(redirected.verb).to eq(:post)
+      expect(redirected.body).to eq('test')
+      expect(redirected.headers['Host']).to eq('example.com')
+    end
+  end
 end


### PR DESCRIPTION
The `Request#redirect` does not work correctly and is untested. I fixed the method and added a spec.
- Add missing proxy argument to new call
- Actually replace the host instead of “adding” one

Replacing the host through `merge!` is not the most transparent... maybe we should look again at the implementation of `Headers#[]=`.

Thanks for this great library ;)
