### PR TITLE
Remove obsolete Chainable#with_response method

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -68,11 +68,6 @@ module HTTP
     end
     alias_method :through, :via
 
-    # Specify the kind of response to return (:auto, :object, :body, :parsed_body)
-    def with_response(response_type)
-      branch default_options.with_response(response_type)
-    end
-
     # Alias for with_response(:object)
     def stream
       with_response(:object)


### PR DESCRIPTION
`Chainable#with_response` was added in `0.5.0`, but now it's not doing anything at all (`Options` don't even know about such method).
