### PR TITLE
Use BUFFER_SIZE instead of nil in Response::Body#readpartial

### DIFF
--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'http/client'
 
 module HTTP
   class Response
@@ -15,7 +16,7 @@ module HTTP
       end
 
       # Read up to length bytes, but return any data that's available
-      def readpartial(length = nil)
+      def readpartial(length = Client::BUFFER_SIZE)
         stream!
         @client.readpartial(length)
       end


### PR DESCRIPTION
This caused the underlying method (Client#readpartial) to raise an ArgumentError when using
Response::Body#each. Sadly I didn't have a good idea how to unit test this. But I checked rubocop this time :)

Cheers'
Hannes
