### PR TITLE
Add HTTP::Response#flush

### DIFF
--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -95,6 +95,12 @@ module HTTP
     end
     alias_method :to_str, :to_s
 
+    # Flushes body and returns self-reference
+    def flush
+      body.to_s
+      self
+    end
+
     # Parsed Content-Type header
     # @return [HTTP::ContentType]
     def content_type

--- a/spec/http/response_spec.rb
+++ b/spec/http/response_spec.rb
@@ -83,4 +83,18 @@ describe HTTP::Response do
       end
     end
   end
+
+  describe '#flush' do
+    let(:body)      { double :to_s => '' }
+    let(:response)  { HTTP::Response.new 200, '1.1', {}, body }
+
+    it 'returns response self-reference' do
+      expect(response.flush).to be response
+    end
+
+    it 'flushes body' do
+      expect(body).to receive :to_s
+      response.flush
+    end
+  end
 end


### PR DESCRIPTION
Method is a syntax sugar to consume body and close underlying socket.
Sample usage:

```
res = HTTP.get("http://example.com").flush
```

Closes #122
