### PR TITLE
status: add 308 because of RFC7238

### DIFF
--- a/lib/http/response/status.rb
+++ b/lib/http/response/status.rb
@@ -76,6 +76,7 @@ module HTTP
         305 => 'Use Proxy',
         306 => 'Reserved',
         307 => 'Temporary Redirect',
+        308 => 'Permanent Redirect',
         400 => 'Bad Request',
         401 => 'Unauthorized',
         402 => 'Payment Required',


### PR DESCRIPTION
see your `lib/http/redirector.rb`:

``` rb
# HTTP status codes which indicate redirects
REDIRECT_CODES = [300, 301, 302, 303, 307, 308].freeze
```

And RFC7238 also listed the 308 status code as a standard one, so add it to the `status.rb`.
