### PR TITLE
Fix indentation in options.rb

### DIFF
--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -112,7 +112,7 @@ module HTTP
         :socket_class     => socket_class,
         :ssl_socket_class => ssl_socket_class,
         :ssl_context      => ssl_context
-     }
+      }
     end
 
     def dup


### PR DESCRIPTION
Offenses:

lib/http/options.rb:115:6: C: Indent the right brace the same as the start of the line where the left brace is.
