### PR TITLE
Convert to RSpec 3 Syntax.

### DIFF
--- a/spec/http/authorization_header/basic_auth_spec.rb
+++ b/spec/http/authorization_header/basic_auth_spec.rb
@@ -23,7 +23,7 @@ describe HTTP::AuthorizationHeader::BasicAuth do
 
     subject { builder.to_s }
 
-    it { should eq "Basic #{Base64.strict_encode64 user_n_pass}" }
-    it { should match(/^Basic [^\s]+$/) }
+    it { is_expected.to eq "Basic #{Base64.strict_encode64 user_n_pass}" }
+    it { is_expected.to match(/^Basic [^\s]+$/) }
   end
 end

--- a/spec/http/authorization_header/bearer_token_spec.rb
+++ b/spec/http/authorization_header/bearer_token_spec.rb
@@ -19,18 +19,18 @@ describe HTTP::AuthorizationHeader::BearerToken do
 
     context 'when :encode => true' do
       let(:options) { {:encode => true} }
-      it { should eq "Bearer #{Base64.strict_encode64 token}" }
-      it { should match(/^Bearer [^\s]+$/) }
+      it { is_expected.to eq "Bearer #{Base64.strict_encode64 token}" }
+      it { is_expected.to match(/^Bearer [^\s]+$/) }
     end
 
     context 'when :encode => false' do
       let(:options) { {:encode => false} }
-      it { should eq "Bearer #{token}" }
+      it { is_expected.to eq "Bearer #{token}" }
     end
 
     context 'when :encode not specified' do
       let(:options) { {} }
-      it { should eq "Bearer #{token}" }
+      it { is_expected.to eq "Bearer #{token}" }
     end
   end
 end

--- a/spec/http/client_spec.rb
+++ b/spec/http/client_spec.rb
@@ -146,7 +146,7 @@ describe HTTP::Client do
     let(:client) { described_class.new }
 
     it 'calls finish_response before actual performance' do
-      TCPSocket.stub(:open) { throw :halt }
+      allow(TCPSocket).to receive(:open) { throw :halt }
       expect(client).to receive(:finish_response)
       catch(:halt) { client.head "http://127.0.0.1:#{ExampleService::PORT}/" }
     end
@@ -185,12 +185,12 @@ describe HTTP::Client do
           RESPONSE
         ]
 
-        socket_spy.stub(:close) { nil }
-        socket_spy.stub(:closed?) { true }
-        socket_spy.stub(:readpartial) { chunks.shift }
-        socket_spy.stub(:<<) { nil }
+        allow(socket_spy).to receive(:close) { nil }
+        allow(socket_spy).to receive(:closed?) { true }
+        allow(socket_spy).to receive(:readpartial) { chunks.shift }
+        allow(socket_spy).to receive(:<<) { nil }
 
-        TCPSocket.stub(:open) { socket_spy }
+        allow(TCPSocket).to receive(:open) { socket_spy }
       end
 
       it 'properly reads body' do

--- a/spec/http/content_type_spec.rb
+++ b/spec/http/content_type_spec.rb
@@ -4,44 +4,100 @@ describe HTTP::ContentType do
   describe '.parse' do
     context 'with text/plain' do
       subject { described_class.parse 'text/plain' }
-      its(:mime_type) { should eq 'text/plain' }
-      its(:charset)   { should be_nil }
+
+      describe '#mime_type' do
+        subject { super().mime_type }
+        it { is_expected.to eq 'text/plain' }
+      end
+
+      describe '#charset' do
+        subject { super().charset }
+        it { is_expected.to be_nil }
+      end
     end
 
     context 'with tEXT/plaIN' do
       subject { described_class.parse 'tEXT/plaIN' }
-      its(:mime_type) { should eq 'text/plain' }
-      its(:charset)   { should be_nil }
+
+      describe '#mime_type' do
+        subject { super().mime_type }
+        it { is_expected.to eq 'text/plain' }
+      end
+
+      describe '#charset' do
+        subject { super().charset }
+        it { is_expected.to be_nil }
+      end
     end
 
     context 'with text/plain; charset=utf-8' do
       subject { described_class.parse 'text/plain; charset=utf-8' }
-      its(:mime_type) { should eq 'text/plain' }
-      its(:charset)   { should eq 'utf-8' }
+
+      describe '#mime_type' do
+        subject { super().mime_type }
+        it { is_expected.to eq 'text/plain' }
+      end
+
+      describe '#charset' do
+        subject { super().charset }
+        it { is_expected.to eq 'utf-8' }
+      end
     end
 
     context 'with text/plain; charset="utf-8"' do
       subject { described_class.parse 'text/plain; charset="utf-8"' }
-      its(:mime_type) { should eq 'text/plain' }
-      its(:charset)   { should eq 'utf-8' }
+
+      describe '#mime_type' do
+        subject { super().mime_type }
+        it { is_expected.to eq 'text/plain' }
+      end
+
+      describe '#charset' do
+        subject { super().charset }
+        it { is_expected.to eq 'utf-8' }
+      end
     end
 
     context 'with text/plain; charSET=utf-8' do
       subject { described_class.parse 'text/plain; charSET=utf-8' }
-      its(:mime_type) { should eq 'text/plain' }
-      its(:charset)   { should eq 'utf-8' }
+
+      describe '#mime_type' do
+        subject { super().mime_type }
+        it { is_expected.to eq 'text/plain' }
+      end
+
+      describe '#charset' do
+        subject { super().charset }
+        it { is_expected.to eq 'utf-8' }
+      end
     end
 
     context 'with text/plain; foo=bar; charset=utf-8' do
       subject { described_class.parse 'text/plain; foo=bar; charset=utf-8' }
-      its(:mime_type) { should eq 'text/plain' }
-      its(:charset)   { should eq 'utf-8' }
+
+      describe '#mime_type' do
+        subject { super().mime_type }
+        it { is_expected.to eq 'text/plain' }
+      end
+
+      describe '#charset' do
+        subject { super().charset }
+        it { is_expected.to eq 'utf-8' }
+      end
     end
 
     context 'with text/plain;charset=utf-8;foo=bar' do
       subject { described_class.parse 'text/plain;charset=utf-8;foo=bar' }
-      its(:mime_type) { should eq 'text/plain' }
-      its(:charset)   { should eq 'utf-8' }
+
+      describe '#mime_type' do
+        subject { super().mime_type }
+        it { is_expected.to eq 'text/plain' }
+      end
+
+      describe '#charset' do
+        subject { super().charset }
+        it { is_expected.to eq 'utf-8' }
+      end
     end
   end
 end

--- a/spec/http/headers_spec.rb
+++ b/spec/http/headers_spec.rb
@@ -198,7 +198,7 @@ describe HTTP::Headers do
     before  { headers.set :set_cookie, %w[hoo=ray woo=hoo] }
     subject { headers.inspect }
 
-    it { should eq '#<HTTP::Headers {"Set-Cookie"=>["hoo=ray", "woo=hoo"]}>' }
+    it { is_expected.to eq '#<HTTP::Headers {"Set-Cookie"=>["hoo=ray", "woo=hoo"]}>' }
   end
 
   describe '#keys' do
@@ -209,7 +209,7 @@ describe HTTP::Headers do
     end
 
     it 'returns uniq keys only' do
-      expect(headers.keys).to have_exactly(2).items
+      expect(headers.keys.size).to eq(2)
     end
 
     it 'normalizes keys' do
@@ -241,12 +241,12 @@ describe HTTP::Headers do
     subject { headers.empty? }
 
     context 'initially' do
-      it { should be_true }
+      it { is_expected.to be_truthy }
     end
 
     context 'when header exists' do
       before { headers.add :accept, 'text/plain' }
-      it { should be_false }
+      it { is_expected.to be_falsey }
     end
 
     context 'when last header was removed' do
@@ -255,7 +255,7 @@ describe HTTP::Headers do
         headers.delete :accept
       end
 
-      it { should be_true }
+      it { is_expected.to be_truthy }
     end
   end
 
@@ -311,8 +311,8 @@ describe HTTP::Headers do
 
     subject(:dupped) { headers.dup }
 
-    it { should be_a described_class }
-    it { should_not be headers }
+    it { is_expected.to be_a described_class }
+    it { is_expected.not_to be headers }
 
     it 'has headers copied' do
       expect(dupped[:content_type]).to eq 'application/json'
@@ -361,8 +361,8 @@ describe HTTP::Headers do
       headers.merge :accept => 'plain/text', :cookie => %w[hoo=ray woo=hoo]
     end
 
-    it { should be_a described_class }
-    it { should_not be headers }
+    it { is_expected.to be_a described_class }
+    it { is_expected.not_to be headers }
 
     it 'does not affects original headers' do
       expect(merged.to_h).to_not eq headers.to_h

--- a/spec/http/request_spec.rb
+++ b/spec/http/request_spec.rb
@@ -50,11 +50,25 @@ describe HTTP::Request do
 
     subject(:redirected) { request.redirect 'http://blog.example.com/' }
 
-    its(:uri)     { should eq URI.parse 'http://blog.example.com/' }
+    describe '#uri' do
+      subject { super().uri }
+      it { is_expected.to eq URI.parse 'http://blog.example.com/' }
+    end
 
-    its(:verb)    { should eq request.verb }
-    its(:body)    { should eq request.body }
-    its(:proxy)   { should eq request.proxy }
+    describe '#verb' do
+      subject { super().verb }
+      it { is_expected.to eq request.verb }
+    end
+
+    describe '#body' do
+      subject { super().body }
+      it { is_expected.to eq request.body }
+    end
+
+    describe '#proxy' do
+      subject { super().proxy }
+      it { is_expected.to eq request.proxy }
+    end
 
     it 'presets new Host header' do
       expect(redirected['Host']).to eq 'blog.example.com'
@@ -63,11 +77,25 @@ describe HTTP::Request do
     context 'with relative URL given' do
       subject(:redirected) { request.redirect '/blog' }
 
-      its(:uri)     { should eq URI.parse 'http://example.com/blog' }
+      describe '#uri' do
+        subject { super().uri }
+        it { is_expected.to eq URI.parse 'http://example.com/blog' }
+      end
 
-      its(:verb)    { should eq request.verb }
-      its(:body)    { should eq request.body }
-      its(:proxy)   { should eq request.proxy }
+      describe '#verb' do
+        subject { super().verb }
+        it { is_expected.to eq request.verb }
+      end
+
+      describe '#body' do
+        subject { super().body }
+        it { is_expected.to eq request.body }
+      end
+
+      describe '#proxy' do
+        subject { super().proxy }
+        it { is_expected.to eq request.proxy }
+      end
 
       it 'keeps Host header' do
         expect(redirected['Host']).to eq 'example.com'
@@ -75,18 +103,36 @@ describe HTTP::Request do
 
       context 'with original URI having non-standard port' do
         let(:request) { HTTP::Request.new(:post, 'http://example.com:8080/', headers, proxy, body) }
-        its(:uri)     { should eq URI.parse 'http://example.com:8080/blog' }
+
+        describe '#uri' do
+          subject { super().uri }
+          it { is_expected.to eq URI.parse 'http://example.com:8080/blog' }
+        end
       end
     end
 
     context 'with relative URL that misses leading slash given' do
       subject(:redirected) { request.redirect 'blog' }
 
-      its(:uri)     { should eq URI.parse 'http://example.com/blog' }
+      describe '#uri' do
+        subject { super().uri }
+        it { is_expected.to eq URI.parse 'http://example.com/blog' }
+      end
 
-      its(:verb)    { should eq request.verb }
-      its(:body)    { should eq request.body }
-      its(:proxy)   { should eq request.proxy }
+      describe '#verb' do
+        subject { super().verb }
+        it { is_expected.to eq request.verb }
+      end
+
+      describe '#body' do
+        subject { super().body }
+        it { is_expected.to eq request.body }
+      end
+
+      describe '#proxy' do
+        subject { super().proxy }
+        it { is_expected.to eq request.proxy }
+      end
 
       it 'keeps Host header' do
         expect(redirected['Host']).to eq 'example.com'
@@ -94,13 +140,21 @@ describe HTTP::Request do
 
       context 'with original URI having non-standard port' do
         let(:request) { HTTP::Request.new(:post, 'http://example.com:8080/', headers, proxy, body) }
-        its(:uri)     { should eq URI.parse 'http://example.com:8080/blog' }
+
+        describe '#uri' do
+          subject { super().uri }
+          it { is_expected.to eq URI.parse 'http://example.com:8080/blog' }
+        end
       end
     end
 
     context 'with new verb given' do
       subject { request.redirect 'http://blog.example.com/', :get }
-      its(:verb) { should be :get }
+
+      describe '#verb' do
+        subject { super().verb }
+        it { is_expected.to be :get }
+      end
     end
   end
 end

--- a/spec/http/response_spec.rb
+++ b/spec/http/response_spec.rb
@@ -20,17 +20,17 @@ describe HTTP::Response do
 
     context 'without Content-Type header' do
       let(:headers) { {} }
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
 
     context 'with Content-Type: text/html' do
       let(:headers) { {'Content-Type' => 'text/html'} }
-      it { should eq 'text/html' }
+      it { is_expected.to eq 'text/html' }
     end
 
     context 'with Content-Type: text/html; charset=utf-8' do
       let(:headers) { {'Content-Type' => 'text/html; charset=utf-8'} }
-      it { should eq 'text/html' }
+      it { is_expected.to eq 'text/html' }
     end
   end
 
@@ -39,17 +39,17 @@ describe HTTP::Response do
 
     context 'without Content-Type header' do
       let(:headers) { {} }
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
 
     context 'with Content-Type: text/html' do
       let(:headers) { {'Content-Type' => 'text/html'} }
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
 
     context 'with Content-Type: text/html; charset=utf-8' do
       let(:headers) { {'Content-Type' => 'text/html; charset=utf-8'} }
-      it { should eq 'utf-8' }
+      it { is_expected.to eq 'utf-8' }
     end
   end
 


### PR DESCRIPTION
I try to run the spec but get following error either invoking `bundle exec rake` or `bundle exec rake spec` or `rake` or `rake spec`:

```
➜  http git:(master) bundle exec rake
/Users/juan/.rubies/ruby-2.1.2/bin/ruby -I/Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib:/Users/juan/.gem/ruby/2.1.2/gems/rspec-support-3.0.4/lib -S /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/exe/rspec ./spec/http/authorization_header/basic_auth_spec.rb ./spec/http/authorization_header/bearer_token_spec.rb ./spec/http/authorization_header_spec.rb ./spec/http/backports/base64_spec.rb ./spec/http/backports/uri_spec.rb ./spec/http/client_spec.rb ./spec/http/content_type_spec.rb ./spec/http/headers/mixin_spec.rb ./spec/http/headers_spec.rb ./spec/http/options/body_spec.rb ./spec/http/options/form_spec.rb ./spec/http/options/headers_spec.rb ./spec/http/options/json_spec.rb ./spec/http/options/merge_spec.rb ./spec/http/options/new_spec.rb ./spec/http/options/proxy_spec.rb ./spec/http/options_spec.rb ./spec/http/redirector_spec.rb ./spec/http/request/writer_spec.rb ./spec/http/request_spec.rb ./spec/http/response/body_spec.rb ./spec/http/response_spec.rb ./spec/http_spec.rb
/Users/juan/.gem/ruby/2.1.2/gems/simplecov-html-0.8.0/lib/simplecov-html.rb:58: warning: possibly useless use of a variable in void context
[2014-08-20 23:40:03] INFO  WEBrick 1.3.1
[2014-08-20 23:40:03] INFO  ruby 2.1.2 (2014-05-08) [x86_64-darwin13.0]
[2014-08-20 23:40:03] INFO  WEBrick::HTTPServer#start: pid=40206 port=65432
[2014-08-20 23:40:03] INFO  WEBrick 1.3.1
[2014-08-20 23:40:03] INFO  ruby 2.1.2 (2014-05-08) [x86_64-darwin13.0]
[2014-08-20 23:40:03] INFO  WEBrick 1.3.1
[2014-08-20 23:40:03] INFO  ruby 2.1.2 (2014-05-08) [x86_64-darwin13.0]
[2014-08-20 23:40:03] INFO  WEBrick::HTTPProxyServer#start: pid=40206 port=8080
[2014-08-20 23:40:03] INFO  WEBrick::HTTPProxyServer#start: pid=40206 port=8081
Coverage report generated for RSpec to /Users/juan/dev/http/coverage. 326 / 638 LOC (51.1%) covered.
[Coveralls] Outside the Travis environment, not sending data.
[2014-08-20 23:40:04] INFO  going to shutdown ...
[2014-08-20 23:40:04] INFO  WEBrick::HTTPProxyServer#start done.
[2014-08-20 23:40:04] INFO  going to shutdown ...
[2014-08-20 23:40:04] INFO  WEBrick::HTTPProxyServer#start done.
[2014-08-20 23:40:04] INFO  going to shutdown ...
[2014-08-20 23:40:04] INFO  WEBrick::HTTPServer#start done.
/Users/juan/dev/http/spec/http/content_type_spec.rb:7:in `block (3 levels) in <top (required)>': undefined method `its' for RSpec::ExampleGroups::HTTPContentType::Parse::WithTextPlain:Class (NoMethodError)
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/example_group.rb:331:in `module_exec'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/example_group.rb:331:in `subclass'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/example_group.rb:227:in `block in define_example_group_method'
    from /Users/juan/dev/http/spec/http/content_type_spec.rb:5:in `block (2 levels) in <top (required)>'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/example_group.rb:331:in `module_exec'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/example_group.rb:331:in `subclass'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/example_group.rb:227:in `block in define_example_group_method'
    from /Users/juan/dev/http/spec/http/content_type_spec.rb:4:in `block in <top (required)>'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/example_group.rb:331:in `module_exec'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/example_group.rb:331:in `subclass'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/example_group.rb:227:in `block in define_example_group_method'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/dsl.rb:41:in `block in expose_example_group_alias'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/dsl.rb:79:in `block (2 levels) in expose_example_group_alias_globally'
    from /Users/juan/dev/http/spec/http/content_type_spec.rb:3:in `<top (required)>'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `load'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `block in load_spec_files'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `each'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/configuration.rb:1058:in `load_spec_files'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:97:in `setup'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:85:in `run'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:70:in `run'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib/rspec/core/runner.rb:38:in `invoke'
    from /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/exe/rspec:4:in `<main>'
/Users/juan/.rubies/ruby-2.1.2/bin/ruby -I/Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/lib:/Users/juan/.gem/ruby/2.1.2/gems/rspec-support-3.0.4/lib -S /Users/juan/.gem/ruby/2.1.2/gems/rspec-core-3.0.4/exe/rspec ./spec/http/authorization_header/basic_auth_spec.rb ./spec/http/authorization_header/bearer_token_spec.rb ./spec/http/authorization_header_spec.rb ./spec/http/backports/base64_spec.rb ./spec/http/backports/uri_spec.rb ./spec/http/client_spec.rb ./spec/http/content_type_spec.rb ./spec/http/headers/mixin_spec.rb ./spec/http/headers_spec.rb ./spec/http/options/body_spec.rb ./spec/http/options/form_spec.rb ./spec/http/options/headers_spec.rb ./spec/http/options/json_spec.rb ./spec/http/options/merge_spec.rb ./spec/http/options/new_spec.rb ./spec/http/options/proxy_spec.rb ./spec/http/options_spec.rb ./spec/http/redirector_spec.rb ./spec/http/request/writer_spec.rb ./spec/http/request_spec.rb ./spec/http/response/body_spec.rb ./spec/http/response_spec.rb ./spec/http_spec.rb failed
```

so I convert the spec using transpec. Now I can run spec and all tests are passed.
