### PR TITLE
This makes SSL connections via proxies work correctly.

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -51,7 +51,7 @@ module HTTP
 
       # TODO: keep-alive support
       @socket = options[:socket_class].open(req.socket_host, req.socket_port)
-      @socket = start_tls(@socket, options) if uri.is_a?(URI::HTTPS)
+      @socket = start_tls(@socket, options) if uri.is_a?(URI::HTTPS) && !req.using_proxy?
 
       req.stream @socket
 


### PR DESCRIPTION
So, when connecting to an https endpoint via a proxy you're supposed to use a plain TCP socket and send '<verb> https://host HTTP/1.1' as the request line. The current code is trying to talk to the proxy using TLS and that doesn't work.
