### PR TITLE
Raise error on unexpected EOF.

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -129,9 +129,6 @@ module HTTP
     # Feeds some more data into parser
     def read_more(size)
       @parser << @socket.readpartial(size) unless @parser.finished?
-      true
-    rescue EOFError
-      false
     end
   end
 end

--- a/spec/http/client_spec.rb
+++ b/spec/http/client_spec.rb
@@ -156,6 +156,11 @@ RSpec.describe HTTP::Client do
       client.get("http://127.0.0.1:#{ExampleService::PORT}/").to_s
     end
 
+    it 'fails on unexpected eof' do
+      expect { client.get("http://127.0.0.1:#{ExampleService::PORT}/eof").to_s }
+        .to raise_error(IOError)
+    end
+
     context 'with HEAD request' do
       it 'does not iterates through body' do
         expect(client).to_not receive(:readpartial)

--- a/spec/support/example_server.rb
+++ b/spec/support/example_server.rb
@@ -23,6 +23,8 @@ class ExampleService < WEBrick::HTTPServlet::AbstractServlet
     when '/redirect-302'
       response.status = 302
       response['Location'] = "http://127.0.0.1:#{PORT}/"
+    when '/eof'
+      request.instance_variable_get('@socket').close
     else
       response.status = 404
     end


### PR DESCRIPTION
Fixes infinite read() loop in the case where the server closes the
connection without sending a valid HTTP response.
