### PR TITLE
Encoding updates

### DIFF
--- a/lib/http/cache.rb
+++ b/lib/http/cache.rb
@@ -88,7 +88,10 @@ module HTTP
       return if rack_resp.nil?
 
       HTTP::Response.new(
-        rack_resp.status, "1.1", rack_resp.headers, stringify(rack_resp.body)
+        :status => rack_resp.status,
+        :version => "1.1",
+        :headers => rack_resp.headers,
+        :body => stringify(rack_resp.body)
       ).caching
     end
 

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -197,6 +197,11 @@ module HTTP
       branch default_options.with_cookies(cookies)
     end
 
+    # Force a specific encoding for response body
+    def encoding(encoding)
+      branch default_options.with_encoding(encoding)
+    end
+
     # Accept the given MIME type(s)
     # @param type
     def accept(type)

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -70,12 +70,12 @@ module HTTP
       end
 
       res = Response.new(
-        @connection.status_code,
-        @connection.http_version,
-        @connection.headers,
-        @connection,
-        options.encoding,
-        req.uri
+        :status => @connection.status_code,
+        :version => @connection.http_version,
+        :headers => @connection.headers,
+        :connection => @connection,
+        :encoding => options.encoding,
+        :uri => req.uri
       )
 
       @connection.finish_response if req.verb == :head

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -73,7 +73,8 @@ module HTTP
         @connection.status_code,
         @connection.http_version,
         @connection.headers,
-        Response::Body.new(@connection),
+        @connection,
+        options.encoding,
         req.uri
       )
 

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -53,7 +53,8 @@ module HTTP
         :cache =>            self.class.default_cache,
         :keep_alive_timeout  => 5,
         :headers =>          {},
-        :cookies =>          {}
+        :cookies =>          {},
+        :encoding =>         nil
       }
 
       opts_w_defaults = defaults.merge(options)
@@ -70,6 +71,10 @@ module HTTP
         cookie = k.is_a?(Cookie) ? k : Cookie.new(k.to_s, v.to_s)
         jar[cookie.name] = cookie.cookie_value
       end
+    end
+
+    def_option :encoding do |encoding|
+      self.encoding = Encoding.find(encoding)
     end
 
     %w(

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -142,7 +142,6 @@ module HTTP
     def resolved_encoding
       return @encoding if @encoding
       return charset if charset
-      return Encoding::UTF_8 if mime_type && mime_type.start_with?("text/")
       Encoding::BINARY
     end
   end

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -31,17 +31,26 @@ module HTTP
     # @return [URI, nil]
     attr_reader :uri
 
-    def initialize(status, version, headers, connection_or_body, encoding = nil, uri = nil) # rubocop:disable ParameterLists
-      @version  = version
-      @uri      = uri && HTTP::URI.parse(uri)
-      @status   = HTTP::Response::Status.new status
-      @headers  = HTTP::Headers.coerce(headers || {})
-      @encoding = encoding
+    # Inits a new instance
+    #
+    # @option opts [Integer] :status Status code
+    # @option opts [String] :version HTTP version
+    # @option opts [Hash] :headers
+    # @option opts [HTTP::Connection] :connection
+    # @option opts [String] :encoding Encoding to use when reading body
+    # @option opts [String] :body
+    # @option opts [String] :uri
+    def initialize(opts)
+      @version  = opts.fetch(:version)
+      @uri      = opts.include?(:uri) && HTTP::URI.parse(opts.fetch(:uri))
+      @status   = HTTP::Response::Status.new opts.fetch(:status)
+      @headers  = HTTP::Headers.coerce(opts.fetch(:headers, {}))
+      @encoding = opts.fetch(:encoding, nil)
 
-      if connection_or_body.is_a? HTTP::Connection
-        @body = Response::Body.new(connection_or_body, resolved_encoding)
+      if opts.include?(:connection)
+        @body = Response::Body.new(opts.fetch(:connection), resolved_encoding)
       else
-        @body = connection_or_body
+        @body = opts.fetch(:body)
       end
     end
 

--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -9,10 +9,11 @@ module HTTP
       include Enumerable
       def_delegator :to_s, :empty?
 
-      def initialize(client)
-        @client       = client
-        @streaming    = nil
-        @contents     = nil
+      def initialize(client, encoding)
+        @client    = client
+        @streaming = nil
+        @contents  = nil
+        @encoding  = encoding
       end
 
       # (see HTTP::Client#readpartial)
@@ -36,9 +37,9 @@ module HTTP
 
         begin
           @streaming = false
-          @contents = "".force_encoding(Encoding::UTF_8)
+          @contents = "".force_encoding(@encoding)
           while (chunk = @client.readpartial)
-            @contents << chunk.force_encoding(Encoding::ASCII_8BIT)
+            @contents << chunk.force_encoding(@encoding)
           end
         rescue
           @contents = nil

--- a/spec/lib/http/cache_spec.rb
+++ b/spec/lib/http/cache_spec.rb
@@ -16,10 +16,11 @@ RSpec.describe HTTP::Cache do
   let(:request) { HTTP::Request.new(:get, "http://example.com/#{sn}") }
 
   let(:origin_response) do
-    HTTP::Response.new(200,
-                       "http/1.1",
-                       {"Cache-Control" => "private"},
-                       "origin")
+    HTTP::Response.new(
+      :status => 200,
+      :version => "http/1.1",
+      :headers => {"Cache-Control" => "private"},
+      :body => "origin")
   end
 
   subject { described_class.new(:metastore => "heap:/", :entitystore => "heap:/") }
@@ -67,10 +68,11 @@ RSpec.describe HTTP::Cache do
 
   context "empty cache, cacheable request, 'no-cache' response" do
     let(:origin_response) do
-      HTTP::Response.new(200,
-                         "http/1.1",
-                         {"Cache-Control" => "no-store"},
-                         "")
+      HTTP::Response.new(
+        :status => 200,
+        :version => "http/1.1",
+        :headers => {"Cache-Control" => "no-store"},
+        :body => "")
     end
     let!(:response) { subject.perform(request, opts) { origin_response } }
 
@@ -81,10 +83,11 @@ RSpec.describe HTTP::Cache do
 
   context "empty cache, cacheable request, 'no-store' response" do
     let(:origin_response) do
-      HTTP::Response.new(200,
-                         "http/1.1",
-                         {"Cache-Control" => "no-store"},
-                         "")
+      HTTP::Response.new(
+        :status => 200,
+        :version => "http/1.1",
+        :headers => {"Cache-Control" => "no-store"},
+        :body => "")
     end
     let!(:response) { subject.perform(request, opts) { origin_response } }
 
@@ -95,10 +98,11 @@ RSpec.describe HTTP::Cache do
 
   context "warm cache, cacheable request, cacheable response" do
     let(:cached_response) do
-      build_cached_response(200,
-                            "1.1",
-                            {"Cache-Control" => "max-age=100"},
-                            "cached")
+      build_cached_response(
+        :status => 200,
+        :version => "1.1",
+        :headers => {"Cache-Control" => "max-age=100"},
+        :body => "cached")
     end
     before do
       subject.perform(request, opts) { cached_response }
@@ -113,11 +117,13 @@ RSpec.describe HTTP::Cache do
 
   context "stale cache, cacheable request, cacheable response" do
     let(:cached_response) do
-      build_cached_response(200,
-                            "1.1",
-                            {"Cache-Control" => "private, max-age=1",
-                             "Date" => (Time.now - 2).httpdate},
-                            "cached") do |t|
+      build_cached_response(
+        :status => 200,
+        :version => "1.1",
+        :headers => {"Cache-Control" => "private, max-age=1",
+                     "Date" => (Time.now - 2).httpdate},
+        :body => "cached"
+      ) do |t|
         t.requested_at = (Time.now - 2)
       end
     end
@@ -133,12 +139,14 @@ RSpec.describe HTTP::Cache do
 
   context "stale cache, cacheable request, not modified response" do
     let(:cached_response) do
-      build_cached_response(200,
-                            "http/1.1",
-                            {"Cache-Control" => "private, max-age=1",
-                             "Etag" => "foo",
-                             "Date" => (Time.now - 2).httpdate},
-                            "") do |x|
+      build_cached_response(
+        :status => 200,
+        :version => "http/1.1",
+        :headers => {"Cache-Control" => "private, max-age=1",
+                     "Etag" => "foo",
+                     "Date" => (Time.now - 2).httpdate},
+        :body => ""
+      ) do |x|
         x.requested_at = (Time.now - 2)
       end
     end
@@ -146,7 +154,13 @@ RSpec.describe HTTP::Cache do
       subject.perform(request, opts) { cached_response }
     end
 
-    let(:origin_response) { HTTP::Response.new(304, "http/1.1", {}, "") }
+    let(:origin_response) do
+      HTTP::Response.new(
+        :status => 304,
+        :version => "http/1.1",
+        :body => ""
+      )
+    end
     let(:response) { subject.perform(request, opts) { origin_response } }
 
     it "makes request with conditional request headers" do
@@ -167,8 +181,8 @@ RSpec.describe HTTP::Cache do
 
   let(:cached_response) { nil } # cold cache by default
 
-  def build_cached_response(*args)
-    r = HTTP::Response.new(*args).caching
+  def build_cached_response(opts)
+    r = HTTP::Response.new(opts).caching
     r.requested_at = r.received_at = Time.now
 
     yield r if block_given?

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -28,11 +28,18 @@ RSpec.describe HTTP::Client do
   end
 
   def redirect_response(location, status = 302)
-    HTTP::Response.new(status, "1.1", {"Location" => location}, "")
+    HTTP::Response.new(
+      :status => status,
+      :version => "1.1",
+      :headers => {"Location" => location},
+      :body => "")
   end
 
   def simple_response(body, status = 200)
-    HTTP::Response.new(status, "1.1", {}, body)
+    HTTP::Response.new(
+      :status => status,
+      :version => "1.1",
+      :body => body)
   end
 
   describe "following redirects" do

--- a/spec/lib/http/options/merge_spec.rb
+++ b/spec/lib/http/options/merge_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe HTTP::Options, "merge" do
       :ssl_socket_class => described_class.default_ssl_socket_class,
       :ssl_context      => nil,
       :cache      => described_class.default_cache,
-      :cookies    => {})
+      :cookies    => {},
+      :encoding   => nil)
   end
 end

--- a/spec/lib/http/redirector_spec.rb
+++ b/spec/lib/http/redirector_spec.rb
@@ -1,6 +1,11 @@
 RSpec.describe HTTP::Redirector do
   def simple_response(status, body = "", headers = {})
-    HTTP::Response.new(status, "1.1", headers, body)
+    HTTP::Response.new(
+      :status => status,
+      :version => "1.1",
+      :headers => headers,
+      :body => body
+    )
   end
 
   def redirect_response(status, location)

--- a/spec/lib/http/request/caching_spec.rb
+++ b/spec/lib/http/request/caching_spec.rb
@@ -24,7 +24,12 @@ RSpec.describe HTTP::Request::Caching do
     it "can construct a new conditional version of itself based on a caching response" do
       mod_date    = Time.now.httpdate
       headers     = {"Etag" => "foo", "Last-Modified" => mod_date}
-      cached_resp = HTTP::Response.new(200, "http/1.1", headers, "")
+      cached_resp = HTTP::Response.new(
+        :status => 200,
+        :version => "http/1.1",
+        :headers => headers,
+        :body => ""
+      )
       cond_req = subject.conditional_on_changes_to(cached_resp)
 
       expect(cond_req.headers["If-None-Match"]).to eq "foo"
@@ -53,7 +58,12 @@ RSpec.describe HTTP::Request::Caching do
     it "can construct a condition version of itself based on a caching response" do
       mod_date    = Time.now.httpdate
       headers     = {"Etag" => "foo", "Last-Modified" => mod_date}
-      cached_resp = HTTP::Response.new(200, "http/1.1", headers, "")
+      cached_resp = HTTP::Response.new(
+        :status => 200,
+        :version => "http/1.1",
+        :headers => headers,
+        :body => ""
+      )
       cond_req    = subject.conditional_on_changes_to(cached_resp)
 
       expect(cond_req.headers["If-None-Match"]).to eq "foo"

--- a/spec/lib/http/response/body_spec.rb
+++ b/spec/lib/http/response/body_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe HTTP::Response::Body do
 
   before         { allow(client).to receive(:readpartial) { chunks.shift } }
 
-  subject(:body) { described_class.new client }
+  subject(:body) { described_class.new client, Encoding::UTF_8 }
 
   it "streams bodies from responses" do
     expect(subject.to_s).to eq "Hello, World!"

--- a/spec/lib/http/response/caching_spec.rb
+++ b/spec/lib/http/response/caching_spec.rb
@@ -1,7 +1,14 @@
 RSpec.describe HTTP::Response::Caching do
   let(:cache_control) { "" }
   let(:headers) { {"cache-control" => cache_control} }
-  let(:response) { HTTP::Response.new(200, "http/1.1", headers, "") }
+  let(:response) do
+    HTTP::Response.new(
+      :status => 200,
+      :version => "http/1.1",
+      :headers => headers,
+      :body => ""
+    )
+  end
 
   subject(:caching_response) { described_class.new response }
 
@@ -175,7 +182,13 @@ RSpec.describe HTTP::Response::Caching do
   end
 
   describe "basic 400 response " do
-    let(:response) { HTTP::Response.new(400, "http/1.1", {}, "") }
+    let(:response) do
+      HTTP::Response.new(
+        :status => 400,
+        :version => "http/1.1",
+        :body => ""
+      )
+    end
 
     it "is not cacheable" do
       expect(subject.cacheable?).to be_falsy

--- a/spec/lib/http/response_spec.rb
+++ b/spec/lib/http/response_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe HTTP::Response do
   let(:body)          { "Hello world!" }
   let(:uri)           { "http://example.com/" }
   let(:headers)       { {} }
-  subject(:response)  { HTTP::Response.new 200, "1.1", headers, body, uri }
+  subject(:response)  { HTTP::Response.new 200, "1.1", headers, body, nil, uri }
 
   it "includes HTTP::Headers::Mixin" do
     expect(described_class).to include HTTP::Headers::Mixin

--- a/spec/lib/http/response_spec.rb
+++ b/spec/lib/http/response_spec.rb
@@ -2,7 +2,16 @@ RSpec.describe HTTP::Response do
   let(:body)          { "Hello world!" }
   let(:uri)           { "http://example.com/" }
   let(:headers)       { {} }
-  subject(:response)  { HTTP::Response.new 200, "1.1", headers, body, nil, uri }
+
+  subject(:response) do
+    HTTP::Response.new(
+      :status => 200,
+      :version => "1.1",
+      :headers => headers,
+      :body => body,
+      :uri => uri
+    )
+  end
 
   it "includes HTTP::Headers::Mixin" do
     expect(described_class).to include HTTP::Headers::Mixin

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe HTTP do
   context "loading binary data" do
     it "is encoded as bytes" do
       response = HTTP.get "#{dummy.endpoint}/bytes"
-      expect(response.to_s.encoding).to eq(Encoding::ASCII_8BIT)
+      expect(response.to_s.encoding).to eq(Encoding::BINARY)
     end
   end
 
@@ -149,8 +149,8 @@ RSpec.describe HTTP do
 
     context "with encoding option" do
       it "respects option" do
-        response = HTTP.get "#{dummy.endpoint}/iso-8859-1", "encoding" => Encoding::ASCII_8BIT
-        expect(response.to_s.encoding).to eq(Encoding::ASCII_8BIT)
+        response = HTTP.get "#{dummy.endpoint}/iso-8859-1", "encoding" => Encoding::BINARY
+        expect(response.to_s.encoding).to eq(Encoding::BINARY)
       end
     end
   end
@@ -162,10 +162,10 @@ RSpec.describe HTTP do
     end
   end
 
-  context "loading text" do
-    it "is utf-8 encoded" do
+  context "loading text with no charset" do
+    it "is binary encoded" do
       response = HTTP.get dummy.endpoint
-      expect(response.to_s.encoding).to eq(Encoding::UTF_8)
+      expect(response.to_s.encoding).to eq(Encoding::BINARY)
     end
   end
 

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require "json"
 
 require "support/dummy_server"
@@ -135,6 +137,28 @@ RSpec.describe HTTP do
     it "is encoded as bytes" do
       response = HTTP.get "#{dummy.endpoint}/bytes"
       expect(response.to_s.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+  end
+
+  context "loading endpoint with charset" do
+    it "uses charset from headers" do
+      response = HTTP.get "#{dummy.endpoint}/iso-8859-1"
+      expect(response.to_s.encoding).to eq(Encoding::ISO8859_1)
+      expect(response.to_s.encode(Encoding::UTF_8)).to eq("testæ")
+    end
+
+    context "with encoding option" do
+      it "respects option" do
+        response = HTTP.get "#{dummy.endpoint}/iso-8859-1", "encoding" => Encoding::ASCII_8BIT
+        expect(response.to_s.encoding).to eq(Encoding::ASCII_8BIT)
+      end
+    end
+  end
+
+  context "passing a string encoding type" do
+    it "finds encoding" do
+      response = HTTP.get dummy.endpoint, "encoding" => "ascii"
+      expect(response.to_s.encoding).to eq(Encoding::ASCII)
     end
   end
 

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class DummyServer < WEBrick::HTTPServer
   class Servlet < WEBrick::HTTPServlet::AbstractServlet
     def self.sockets
@@ -127,6 +129,11 @@ class DummyServer < WEBrick::HTTPServer
       bytes = [80, 75, 3, 4, 20, 0, 0, 0, 8, 0, 123, 104, 169, 70, 99, 243, 243]
       res["Content-Type"] = "application/octet-stream"
       res.body = bytes.pack("c*")
+    end
+
+    get "/iso-8859-1" do |_req, res|
+      res["Content-Type"] = "text/plain; charset=ISO-8859-1"
+      res.body = "testæ".encode(Encoding::ISO8859_1)
     end
 
     get "/cookies" do |req, res|


### PR DESCRIPTION
Should resolve #224

Adds an encoding option and sets the body encoding based on this order of priorities:
1. encoding option
2. charset in content-type
3. UTF-8 if mime-type starts with 'text/' (I believe the spec says ISO-8859-1, but I think UTF-8 is more commonly assumed)
4. Binary

