### PR TITLE
Fixed exceptionless NIO handling for EOF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 0.9.2 (2015-08-18)
+* Fixed exceptionless NIO EOF handling. (@zanker)
+
 ## 0.9.1 (2015-08-14)
 
 * Fix params special-chars escaping. See #246. (@ixti)

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -208,9 +208,11 @@ module HTTP
       return if @parser.finished?
 
       value = @socket.readpartial(size)
-      @parser << value unless value == :eof
-
-      nil
+      if value == :eof
+        :eof
+      elsif value
+        @parser << value
+      end
     end
   end
 end

--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -76,7 +76,11 @@ module HTTP
 
           loop do
             result = socket.read_nonblock(size, :exception => false)
-            break result unless result == :wait_readable
+            if result.nil?
+              return :eof
+            elsif result != :wait_readable
+              return result
+            end
 
             IO.select([socket], nil, nil, time_left)
             log_time

--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -55,7 +55,11 @@ module HTTP
         def readpartial(size)
           loop do
             result = socket.read_nonblock(size, :exception => false)
-            break result unless result == :wait_readable
+            if result.nil?
+              return :eof
+            elsif result != :wait_readable
+              return result
+            end
 
             unless IO.select([socket], nil, nil, read_timeout)
               fail TimeoutError, "Read timed out after #{read_timeout} seconds"

--- a/lib/http/version.rb
+++ b/lib/http/version.rb
@@ -1,3 +1,3 @@
 module HTTP
-  VERSION = "0.9.1".freeze
+  VERSION = "0.9.2".freeze
 end


### PR DESCRIPTION
:(

So in true Ruby tradition. Exceptionless NIO has no real documentation, I misunderstood a patch I was reading originally and thought it returned `:eof` on EOF. Apparently it returns nil (super obvious right?)

I just looked again and found: https://bugs.ruby-lang.org/issues/11358 and reading _that_ patch shows returning a nil is correct.

This won't happen in general use, but it's still not great.