### PR TITLE
Remove usage of ActiveSupport's #present? method

### DIFF
--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -87,7 +87,7 @@ module HTTP
       private
 
       def write(data)
-        while data.present?
+        until data.empty?
           length = @socket.write(data)
           if data.length > length
             data = data[length..-1]


### PR DESCRIPTION
Replaces it with `#empty?`