### PR TITLE
remove #present? method that’s not on String

### DIFF
--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -87,7 +87,7 @@ module HTTP
       private
 
       def write(data)
-        while data.present?
+        while data
           length = @socket.write(data)
           if data.length > length
             data = data[length..-1]


### PR DESCRIPTION
  it is available on String when running the test suite, because
  active support is a dependency of a test env only gem
  “certificate_authority”