### PR TITLE
Hide implementation details

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -35,6 +35,9 @@ module HTTP
       send_proxy_connect_request(req)
       start_tls(req, options)
       reset_timer
+
+    rescue SocketError, SystemCallError => ex
+      raise HTTP::Error.new(ex)
     end
 
     # @see (HTTP::Response::Parser#status_code)

--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -16,4 +16,7 @@ module HTTP
 
   # Header name is invalid
   class InvalidHeaderNameError < Error; end
+
+  # Something unexpected happened, probably a bug
+  class UnexpectedError < Error;end
 end

--- a/lib/http/response/status.rb
+++ b/lib/http/response/status.rb
@@ -111,6 +111,7 @@ module HTTP
       end
 
       def __setobj__(obj)
+        raise HTTP::UnexpectedError.new('expected object to respond_to #to_i') unless obj.respond_to?(:to_i)
         @code = obj.to_i
       end
 

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe HTTP::Request::Writer do
       let(:body) { 123 }
 
       it "raises an error" do
-        expect { writer }.to raise_error
+        expect { writer }.to raise_error(HTTP::RequestError)
       end
     end
   end
@@ -59,12 +59,12 @@ RSpec.describe HTTP::Request::Writer do
 
       context "when Transfer-Encoding not set" do
         let(:headers) { HTTP::Headers.new }
-        specify { expect { writer.stream }.to raise_error }
+        specify { expect { writer.stream }.to raise_error(HTTP::RequestError) }
       end
 
       context "when Transfer-Encoding is not chunked" do
         let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "gzip" }
-        specify { expect { writer.stream }.to raise_error }
+        specify { expect { writer.stream }.to raise_error(HTTP::RequestError) }
       end
     end
 

--- a/spec/lib/http/response/status_spec.rb
+++ b/spec/lib/http/response/status_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe HTTP::Response::Status do
   describe ".new" do
     it "fails if given value does not respond to #to_i" do
-      expect { described_class.new double }.to raise_error
+      expect { described_class.new double }.to raise_error(HTTP::UnexpectedError)
     end
 
     it "accepts any object that responds to #to_i" do

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -337,5 +337,10 @@ RSpec.describe HTTP do
       client = HTTP.headers("Cookie" => "foo=bar").cookies(:baz => :moo)
       expect(client.get(endpoint).to_s).to eq "foo: bar\nbaz: moo"
     end
+
+    it "throws correct error" do
+      expect { HTTP.get('http://thishostshouldnotexists.com') }.to raise_error(HTTP::Error)
+      expect { HTTP.get('http://127.0.0.1:000') }.to raise_error(HTTP::Error)
+    end
   end
 end


### PR DESCRIPTION
Dont leak implementation details error from the connection class.

```SocketError``` and ```SystemCallError``` is rescued and reraised as a ```HTTP::Error``` instead.

Maybe there should be a ```HTTP::ConnectionError < HTTP::Error``` class.