### PR TITLE
rspec raise_error wants to know which type of error it is expecting.

### DIFF
--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -16,4 +16,7 @@ module HTTP
 
   # Header name is invalid
   class InvalidHeaderNameError < Error; end
+
+  # Something unexpected happened, probably a bug
+  class UnexpectedError < Error;end
 end

--- a/lib/http/response/status.rb
+++ b/lib/http/response/status.rb
@@ -111,6 +111,7 @@ module HTTP
       end
 
       def __setobj__(obj)
+        raise HTTP::UnexpectedError.new('expected object to respond_to #to_i') unless obj.respond_to?(:to_i)
         @code = obj.to_i
       end
 

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe HTTP::Request::Writer do
       let(:body) { 123 }
 
       it "raises an error" do
-        expect { writer }.to raise_error
+        expect { writer }.to raise_error(HTTP::RequestError)
       end
     end
   end
@@ -59,12 +59,12 @@ RSpec.describe HTTP::Request::Writer do
 
       context "when Transfer-Encoding not set" do
         let(:headers) { HTTP::Headers.new }
-        specify { expect { writer.stream }.to raise_error }
+        specify { expect { writer.stream }.to raise_error(HTTP::RequestError) }
       end
 
       context "when Transfer-Encoding is not chunked" do
         let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "gzip" }
-        specify { expect { writer.stream }.to raise_error }
+        specify { expect { writer.stream }.to raise_error(HTTP::RequestError) }
       end
     end
 

--- a/spec/lib/http/response/status_spec.rb
+++ b/spec/lib/http/response/status_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe HTTP::Response::Status do
   describe ".new" do
     it "fails if given value does not respond to #to_i" do
-      expect { described_class.new double }.to raise_error
+      expect { described_class.new double }.to raise_error(HTTP::UnexpectedError)
     end
 
     it "accepts any object that responds to #to_i" do


### PR DESCRIPTION
Also added a HTTP::UnexpectedError which can be used to indicate that something went wrong.