### PR TITLE
Remove all deprecations (closes #208)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,19 @@
+## HEAD
+
+* [#265](https://github.com/httprb/http/pull/265/):
+  Remove deprecations ([@tarcieri]):
+  - HTTP::Chainable#with_follow (use #follow)
+  - HTTP::Chainable#with, #with_headers (use #headers)
+  - HTTP::Chainable#auth(:basic, ...) (use #basic_auth)
+  - HTTP::Chainable#default_headers (use #default_options[:headers])
+  - HTTP::Headers#append (use #add)
+  - HTTP::Options#[] hash-like API deprecated in favor of explicit methods
+  - HTTP::Request#request_header (use #headline)
+  - HTTP::Response::STATUS_CODES (use HTTP::Status::REASONS)
+  - HTTP::Response::SYMBOL_TO_STATUS_CODE (no replacement)
+  - HTTP::Response#status_code (use #status or #code)
+  - HTTP::Response::Status#symbolize (use #to_sym)
+
 ## 0.9.8 (2015-09-29)
 
 * [#260](https://github.com/httprb/http/pull/258):

--- a/Gemfile
+++ b/Gemfile
@@ -20,11 +20,11 @@ end
 group :test do
   gem "backports"
   gem "coveralls"
-  gem "simplecov",    ">= 0.9"
-  gem "json",         ">= 1.8.1"
-  gem "rspec",        "~> 3.0"
+  gem "simplecov", ">= 0.9"
+  gem "json",      ">= 1.8.1"
+  gem "rubocop",   "=  0.35.1"
+  gem "rspec",     "~> 3.0"
   gem "rspec-its"
-  gem "rubocop"
   gem "yardstick"
   gem "certificate_authority"
 end

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -83,7 +83,10 @@ module HTTP
     #   @option options [Float] :write Write timeout
     #   @option options [Float] :connect Connect timeout
     def timeout(klass, options = {})
-      klass, options = :per_operation, klass if klass.is_a? Hash
+      if klass.is_a? Hash
+        options = klass
+        klass   = :per_operation
+      end
 
       klass = case klass.to_sym
               when :null          then HTTP::Timeout::Null

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -166,23 +166,11 @@ module HTTP
       branch default_options.with_follow opts
     end
 
-    # @deprecated will be removed in 1.0.0
-    # @see #follow
-    alias_method :with_follow, :follow
-
     # Make a request with the given headers
     # @param headers
     def headers(headers)
       branch default_options.with_headers(headers)
     end
-
-    # @deprecated will be removed in 1.0.0
-    # @see #headers
-    alias_method :with, :headers
-
-    # @deprecated will be removed in 1.0.0
-    # @see #headers
-    alias_method :with_headers, :headers
 
     # Make a request with the given cookies
     def cookies(cookies)
@@ -197,10 +185,7 @@ module HTTP
 
     # Make a request with the given Authorization header
     # @param [#to_s] value Authorization header value
-    def auth(value, opts = nil)
-      # shim for deprecated auth(:basic, opts).
-      # will be removed in 0.8.0
-      return basic_auth(opts) if :basic == value
+    def auth(value)
       headers Headers::AUTHORIZATION => value.to_s
     end
 
@@ -227,21 +212,6 @@ module HTTP
     # @return [HTTP::Options]
     def default_options=(opts)
       @default_options = HTTP::Options.new(opts)
-    end
-
-    # @deprecated Will be removed in 1.0.0; Use `#default_options#headers`
-    # Get headers of HTTP options
-    def default_headers
-      default_options.headers
-    end
-
-    # Set headers of HTTP options
-    # @deprecated Will be removed in 1.0.0; Use `#headers`
-    # @param headers
-    def default_headers=(headers)
-      @default_options = default_options.dup do |opts|
-        opts.headers = headers
-      end
     end
 
     private

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -152,7 +152,7 @@ module HTTP
 
       unless ssl_context
         ssl_context = OpenSSL::SSL::SSLContext.new
-        ssl_context.set_params(Hash(options.ssl))
+        ssl_context.set_params(options.ssl || {})
       end
 
       @socket.start_tls(req.uri.host, options.ssl_socket_class, ssl_context)

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -22,15 +22,15 @@ module HTTP
     # @param [HTTP::Options] options
     def initialize(req, options)
       @persistent           = options.persistent?
-      @keep_alive_timeout   = options[:keep_alive_timeout].to_f
+      @keep_alive_timeout   = options.keep_alive_timeout.to_f
       @pending_request      = false
       @pending_response     = false
       @failed_proxy_connect = false
 
       @parser = Response::Parser.new
 
-      @socket = options[:timeout_class].new(options[:timeout_options])
-      @socket.connect(options[:socket_class], req.socket_host, req.socket_port)
+      @socket = options.timeout_class.new(options.timeout_options)
+      @socket.connect(options.socket_class, req.socket_host, req.socket_port)
 
       send_proxy_connect_request(req)
       start_tls(req, options)
@@ -148,14 +148,14 @@ module HTTP
     def start_tls(req, options)
       return unless req.uri.https? && !failed_proxy_connect?
 
-      ssl_context = options[:ssl_context]
+      ssl_context = options.ssl_context
 
       unless ssl_context
         ssl_context = OpenSSL::SSL::SSLContext.new
-        ssl_context.set_params(options[:ssl] || {})
+        ssl_context.set_params(Hash(options.ssl))
       end
 
-      @socket.start_tls(req.uri.host, options[:ssl_socket_class], ssl_context)
+      @socket.start_tls(req.uri.host, options.ssl_socket_class, ssl_context)
     end
 
     # Open tunnel through proxy

--- a/lib/http/headers.rb
+++ b/lib/http/headers.rb
@@ -51,9 +51,6 @@ module HTTP
       Array(value).each { |v| @pile << [name, v.to_s] }
     end
 
-    # @deprecated Will be removed in 1.0.0
-    alias_method :append, :add
-
     # Returns list of header values if any.
     #
     # @return [Array<String>]

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -91,15 +91,6 @@ module HTTP
       !persistent.nil?
     end
 
-    # @deprecated
-    def [](option)
-      send(option)
-    rescue
-      warn "[DEPRECATED] `HTTP::Options#[:#{option}]` was deprecated. " \
-        "Use `HTTP::Options##{option}` instead."
-      nil
-    end
-
     def merge(other)
       h1 = to_hash
       h2 = other.to_hash
@@ -119,7 +110,7 @@ module HTTP
     def to_hash
       hash_pairs = self.class.
                    defined_options.
-                   flat_map { |opt_name| [opt_name, self[opt_name]] }
+                   flat_map { |opt_name| [opt_name, send(opt_name)] }
       Hash[*hash_pairs]
     end
 

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -126,9 +126,6 @@ module HTTP
       "#{verb.to_s.upcase} #{request_uri.omit :fragment} HTTP/#{version}"
     end
 
-    # @deprecated Will be removed in 1.0.0
-    alias_method :request_header, :headline
-
     # Compute HTTP request header SSL proxy connection
     def proxy_connect_header
       "CONNECT #{host}:#{port} HTTP/#{version}"

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -14,13 +14,6 @@ module HTTP
 
     include HTTP::Headers::Mixin
 
-    # @deprecated Will be removed in 1.0.0
-    #   Use Status::REASONS
-    STATUS_CODES = Status::REASONS
-
-    # @deprecated Will be removed in 1.0.0
-    SYMBOL_TO_STATUS_CODE = Hash[STATUS_CODES.map { |k, v| [v.downcase.gsub(/\s|-/, "_").to_sym, k] }].freeze
-
     # @return [Status]
     attr_reader :status
 
@@ -45,9 +38,6 @@ module HTTP
     # @!method code
     #   @return (see HTTP::Response::Status#code)
     def_delegator :status, :code
-
-    # @deprecated Will be removed in 1.0.0
-    alias_method :status_code, :code
 
     # @!method to_s
     #   (see HTTP::Response::Body#to_s)

--- a/lib/http/response/parser.rb
+++ b/lib/http/response/parser.rb
@@ -42,7 +42,8 @@ module HTTP
       end
 
       def chunk
-        chunk, @chunk = @chunk, nil
+        chunk  = @chunk
+        @chunk = nil
         chunk
       end
 

--- a/lib/http/response/status.rb
+++ b/lib/http/response/status.rb
@@ -91,9 +91,6 @@ module HTTP
         SYMBOLS[code]
       end
 
-      # @deprecated Will be removed in 1.0.0
-      alias_method :symbolize, :to_sym
-
       # Printable version of HTTP Status, surrounded by quote marks,
       # with special characters escaped.
       #

--- a/spec/lib/http/options_spec.rb
+++ b/spec/lib/http/options_spec.rb
@@ -1,9 +1,8 @@
 RSpec.describe HTTP::Options do
   subject { described_class.new(:response => :body) }
 
-  it "behaves like a Hash for reading" do
-    expect(subject[:response]).to eq(:body)
-    expect(subject[:nosuchone]).to be nil
+  it "has reader methods for attributes" do
+    expect(subject.response).to eq(:body)
   end
 
   it "coerces to a Hash" do

--- a/spec/lib/http/response/status_spec.rb
+++ b/spec/lib/http/response/status_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe HTTP::Response::Status do
     end
   end
 
-  describe "#symbolize" do
-    subject { described_class.new(code).symbolize }
+  describe "#to_sym" do
+    subject { described_class.new(code).to_sym }
 
     context "with unknown code" do
       let(:code) { 1024 }

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -201,12 +201,12 @@ RSpec.describe HTTP do
   describe ".auth" do
     it "sets Authorization header to the given value" do
       client = HTTP.auth "abc"
-      expect(client.default_headers[:authorization]).to eq "abc"
+      expect(client.default_options.headers[:authorization]).to eq "abc"
     end
 
     it "accepts any #to_s object" do
       client = HTTP.auth double :to_s => "abc"
-      expect(client.default_headers[:authorization]).to eq "abc"
+      expect(client.default_options.headers[:authorization]).to eq "abc"
     end
   end
 
@@ -225,7 +225,7 @@ RSpec.describe HTTP do
 
     it "sets Authorization header with proper BasicAuth value" do
       client = HTTP.basic_auth :user => "foo", :pass => "bar"
-      expect(client.default_headers[:authorization]).
+      expect(client.default_options.headers[:authorization]).
         to match(%r{^Basic [A-Za-z0-9+/]+=*$})
     end
   end


### PR DESCRIPTION
I'd still like to go forward with a 1.0 release (and at least blog about it)

This removes all deprecations and documents replacements where applicable.