### PR TITLE
add socket_factory option

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -30,7 +30,11 @@ module HTTP
       @parser = Response::Parser.new
 
       @socket = options.timeout_class.new(options.timeout_options)
-      @socket.connect(options.socket_class, req.socket_host, req.socket_port)
+      if options.socket_factory
+        @socket.factory_connect(options.socket_factory, req.socket_host, req.socket_port)
+      else
+        @socket.connect(options.socket_class, req.socket_host, req.socket_port)
+      end
 
       send_proxy_connect_request(req)
       start_tls(req, options)

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -43,6 +43,7 @@ module HTTP
         :timeout_class      => self.class.default_timeout_class,
         :timeout_options    => {},
         :socket_class       => self.class.default_socket_class,
+        :socket_factory     => nil,
         :ssl_socket_class   => self.class.default_ssl_socket_class,
         :ssl                => {},
         :keep_alive_timeout => 5,
@@ -68,7 +69,7 @@ module HTTP
 
     %w(
       proxy params form json body follow response
-      socket_class ssl_socket_class ssl_context ssl
+      socket_class socket_factory ssl_socket_class ssl_context ssl
       persistent keep_alive_timeout timeout_class timeout_options
     ).each do |method_name|
       def_option method_name

--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -27,6 +27,15 @@ module HTTP
         log_time
       end
 
+      def factory_connect(socket_factory, host, port)
+        reset_timer
+        ::Timeout.timeout(time_left, TimeoutError) do
+          @socket = socket_factory.call(host, port)
+        end
+
+        log_time
+      end
+
       def connect_ssl
         reset_timer
 

--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -18,6 +18,11 @@ module HTTP
         @socket = socket_class.open(host, port)
       end
 
+      # Connects to a socket using a factory (callable)
+      def factory_connect(socket_factory, host, port)
+        @socket = socket_factory.call(host, port)
+      end
+
       # Starts a SSL connection on a socket
       def connect_ssl
         @socket.connect

--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -25,6 +25,12 @@ module HTTP
         end
       end
 
+      def factory_connect(socket_factory, host, port)
+        ::Timeout.timeout(connect_timeout, TimeoutError) do
+          @socket = socket_factory.call(host, port)
+        end
+      end
+
       def connect_ssl
         rescue_readable do
           rescue_writable do

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -231,6 +231,21 @@ RSpec.describe HTTP::Client do
     end
   end
 
+  describe "working with a socket factory" do
+    let(:client) do
+      described_class.new(socket_factory: lambda { |host, port|
+        sock = TCPSocket.open(host, port)
+        sock.setsockopt(Socket::Option.int(:INET, Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1))
+        sock
+      })
+    end
+
+    it "just works" do
+      response = client.get(dummy.endpoint)
+      expect(response.body.to_s).to eq("<!doctype html>")
+    end
+  end
+
   describe "#perform" do
     let(:client) { described_class.new }
 

--- a/spec/lib/http/options/merge_spec.rb
+++ b/spec/lib/http/options/merge_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe HTTP::Options, "merge" do
       :proxy     => {:proxy_address => "127.0.0.1", :proxy_port => 8080},
       :follow => nil,
       :socket_class     => described_class.default_socket_class,
+      :socket_factory   => nil,
       :ssl_socket_class => described_class.default_ssl_socket_class,
       :ssl_context      => nil,
       :cookies          => {})


### PR DESCRIPTION
Add an option for custom socket creation, e.g.

```
HTTP::Client.new(socket_factory: lambda { |host, port|
  sock = TCPSocket.open(host, port)
  sock.setsockopt(Socket::Option.int(:INET, Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1))
  sock
})
```