### PR TITLE
Set default HTTP::Response::Body encoding to Encoding::BINARY

### DIFF
--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -9,7 +9,7 @@ module HTTP
       include Enumerable
       def_delegator :to_s, :empty?
 
-      def initialize(client, encoding)
+      def initialize(client, encoding = Encoding::BINARY)
         @client    = client
         @streaming = nil
         @contents  = nil


### PR DESCRIPTION
Otherwise we break Webmock