### PR TITLE
Use io/wait on platforms where it's available

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  DisplayCopNames: true
+
 Metrics/BlockNesting:
   Max: 2
 

--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -50,26 +50,43 @@ module HTTP
       end
       alias_method :<<, :write
 
+      # These cops can be re-eanbled after we go Ruby 2.0+ only
+      # rubocop:disable Lint/UselessAccessModifier, Metrics/BlockNesting
+
       private
 
-      # Retry reading
-      def rescue_readable
-        yield
-      rescue IO::WaitReadable
-        if IO.select([socket], nil, nil, read_timeout)
-          retry
-        else
+      if RUBY_VERSION < "2.0.0"
+        # Retry reading
+        def rescue_readable
+          yield
+        rescue IO::WaitReadable
+          retry if IO.select([socket], nil, nil, read_timeout)
           raise TimeoutError, "Read timed out after #{read_timeout} seconds"
         end
-      end
 
-      # Retry writing
-      def rescue_writable
-        yield
-      rescue IO::WaitWritable
-        if IO.select(nil, [socket], nil, write_timeout)
-          retry
-        else
+        # Retry writing
+        def rescue_writable
+          yield
+        rescue IO::WaitWritable
+          retry if IO.select(nil, [socket], nil, write_timeout)
+          raise TimeoutError, "Write timed out after #{write_timeout} seconds"
+        end
+      else
+        require "io/wait"
+
+        # Retry reading
+        def rescue_readable
+          yield
+        rescue IO::WaitReadable
+          retry if socket.to_io.wait_readable(read_timeout)
+          raise TimeoutError, "Read timed out after #{read_timeout} seconds"
+        end
+
+        # Retry writing
+        def rescue_writable
+          yield
+        rescue IO::WaitWritable
+          retry if socket.to_io.wait_writable(write_timeout)
           raise TimeoutError, "Write timed out after #{write_timeout} seconds"
         end
       end


### PR DESCRIPTION
IO.select is an expensive call, because it has to build an fd_set (large bitfield) from an array each time we invoke it.

We're just interested in IO readiness, so on Ruby 2.0+ we can use the io/wait API instead, which adds wait_readable/wait_writable to IO objects.

cc @zanker @nerdrew 