### PR TITLE
Flush response before following redirect

### DIFF
--- a/lib/http/redirector.rb
+++ b/lib/http/redirector.rb
@@ -54,6 +54,8 @@ module HTTP
         fail TooManyRedirectsError if too_many_hops?
         fail EndlessRedirectError  if endless_loop?
 
+        @response.flush
+
         @request  = redirect_to @response.headers[Headers::LOCATION]
         @response = yield @request
       end


### PR DESCRIPTION
Otherwise redirect following will not work on persistent connections:

``` ruby
HTTP.follow.persistent("https://play.google.com") do |http|
  http.get("https://play.google.com/store/apps/")
end
```

fails with obvious state error:

```
HTTP::StateError: Tried to send a request while one is pending already. Make sure you read off the body.
from /home/ixti/.gem/ruby/2.3.0/gems/http-1.0.1/lib/http/connection.rb:63:in `send_request'
```