### PR TITLE
Update to RuboCop 0.36

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,17 +61,8 @@ Style/HashSyntax:
 Style/Lambda:
   Enabled: false
 
-Style/SingleSpaceBeforeFirstArg:
-  Enabled: false
-
 Style/SpaceAroundOperators:
-  MultiSpaceAllowedForOperators:
-    - "="
-    - "=>"
-    - "||"
-    - "||="
-    - "&&"
-    - "&&="
+  AllowForAlignment: true
 
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :test do
   gem "coveralls"
   gem "simplecov", ">= 0.9"
   gem "json",      ">= 1.8.1"
-  gem "rubocop",   "=  0.35.1"
+  gem "rubocop",   "=  0.36.0"
   gem "rspec",     "~> 3.0"
   gem "rspec-its"
   gem "yardstick"

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -20,6 +20,6 @@ module HTTP
 
   class << self
     # HTTP[:accept => 'text/html'].get(...)
-    alias_method :[], :headers
+    alias [] headers
   end
 end

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "base64"
 
 require "http/headers"
@@ -153,13 +154,11 @@ module HTTP
       proxy_hash[:proxy_username] = proxy[2] if proxy[2].is_a?(String)
       proxy_hash[:proxy_password] = proxy[3] if proxy[3].is_a?(String)
 
-      if [2, 4].include?(proxy_hash.keys.size)
-        branch default_options.with_proxy(proxy_hash)
-      else
-        fail(RequestError, "invalid HTTP proxy: #{proxy_hash}")
-      end
+      fail(RequestError, "invalid HTTP proxy: #{proxy_hash}") unless [2, 4].include?(proxy_hash.keys.size)
+
+      branch default_options.with_proxy(proxy_hash)
     end
-    alias_method :through, :via
+    alias through via
 
     # Make client follow redirects.
     # @param opts
@@ -206,7 +205,7 @@ module HTTP
       user = opts.fetch :user
       pass = opts.fetch :pass
 
-      auth("Basic " << Base64.strict_encode64("#{user}:#{pass}"))
+      auth("Basic " + Base64.strict_encode64("#{user}:#{pass}"))
     end
 
     # Get options for HTTP

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "forwardable"
 
 require "http/form_data"
@@ -137,13 +138,10 @@ module HTTP
       headers = opts.headers
 
       # Tell the server to keep the conn open
-      if default_options.persistent?
-        headers[Headers::CONNECTION] = KEEP_ALIVE
-      else
-        headers[Headers::CONNECTION] = CLOSE
-      end
+      headers[Headers::CONNECTION] = default_options.persistent? ? KEEP_ALIVE : CLOSE
 
       cookies = opts.cookies.values
+
       unless cookies.empty?
         cookies = opts.headers.get(Headers::COOKIE).concat(cookies).join("; ")
         headers[Headers::COOKIE] = cookies

--- a/lib/http/headers.rb
+++ b/lib/http/headers.rb
@@ -30,7 +30,7 @@ module HTTP
       delete(name)
       add(name, value)
     end
-    alias_method :[]=, :set
+    alias []= set
 
     # Removes header.
     #
@@ -80,7 +80,7 @@ module HTTP
     def to_h
       Hash[keys.map { |k| [k, self[k]] }]
     end
-    alias_method :to_hash, :to_h
+    alias to_hash to_h
 
     # Returns headers key/value pairs.
     #
@@ -179,7 +179,7 @@ module HTTP
         object.each { |k, v| headers.add k, v }
         headers
       end
-      alias_method :[], :coerce
+      alias [] coerce
     end
 
     private

--- a/lib/http/headers/known.rb
+++ b/lib/http/headers/known.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module HTTP
   class Headers
     # Content-Types that are acceptable for the response.

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "forwardable"
 require "base64"
 require "time"
@@ -23,26 +24,28 @@ module HTTP
     # Default User-Agent header value
     USER_AGENT = "http.rb/#{HTTP::VERSION}".freeze
 
-    # RFC 2616: Hypertext Transfer Protocol -- HTTP/1.1
-    METHODS = [:options, :get, :head, :post, :put, :delete, :trace, :connect]
+    METHODS = [
+      # RFC 2616: Hypertext Transfer Protocol -- HTTP/1.1
+      :options, :get, :head, :post, :put, :delete, :trace, :connect,
 
-    # RFC 2518: HTTP Extensions for Distributed Authoring -- WEBDAV
-    METHODS.concat [:propfind, :proppatch, :mkcol, :copy, :move, :lock, :unlock]
+      # RFC 2518: HTTP Extensions for Distributed Authoring -- WEBDAV
+      :propfind, :proppatch, :mkcol, :copy, :move, :lock, :unlock,
 
-    # RFC 3648: WebDAV Ordered Collections Protocol
-    METHODS.concat [:orderpatch]
+      # RFC 3648: WebDAV Ordered Collections Protocol
+      :orderpatch,
 
-    # RFC 3744: WebDAV Access Control Protocol
-    METHODS.concat [:acl]
+      # RFC 3744: WebDAV Access Control Protocol
+      :acl,
 
-    # draft-dusseault-http-patch: PATCH Method for HTTP
-    METHODS.concat [:patch]
+      # draft-dusseault-http-patch: PATCH Method for HTTP
+      :patch,
 
-    # draft-reschke-webdav-search: WebDAV Search
-    METHODS.concat [:search]
+      # draft-reschke-webdav-search: WebDAV Search
+      :search
+    ].freeze
 
     # Allowed schemes
-    SCHEMES = [:http, :https, :ws, :wss]
+    SCHEMES = [:http, :https, :ws, :wss].freeze
 
     # Default ports of supported schemes
     PORTS = {
@@ -50,7 +53,7 @@ module HTTP
       :https  => 443,
       :ws     => 80,
       :wss    => 443
-    }
+    }.freeze
 
     # Method is given as a lowercase symbol e.g. :get, :post
     attr_reader :verb
@@ -71,7 +74,7 @@ module HTTP
     # @option opts [String] :body
     def initialize(opts)
       @verb   = opts.fetch(:verb).to_s.downcase.to_sym
-      @uri    = normalize_uri(opts.fetch :uri)
+      @uri    = normalize_uri(opts.fetch(:uri))
       @scheme = @uri.scheme.to_s.downcase.to_sym if @uri.scheme
 
       fail(UnsupportedMethodError, "unknown method: #{verb}") unless METHODS.include?(@verb)

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "http/headers"
 
 module HTTP
@@ -16,7 +17,7 @@ module HTTP
       CHUNKED_END = "#{ZERO}#{CRLF}#{CRLF}".freeze
 
       # Types valid to be used as body source
-      VALID_BODY_TYPES = [String, NilClass, Enumerable]
+      VALID_BODY_TYPES = [String, NilClass, Enumerable].freeze
 
       def initialize(socket, body, headers, headline)
         @body           = body
@@ -62,7 +63,7 @@ module HTTP
       def join_headers
         # join the headers array with crlfs, stick two on the end because
         # that ends the request header
-        @request_header.join(CRLF) + (CRLF) * 2
+        @request_header.join(CRLF) + CRLF * 2
       end
 
       def send_request
@@ -94,11 +95,8 @@ module HTTP
       def write(data)
         until data.empty?
           length = @socket.write(data)
-          if data.length > length
-            data = data[length..-1]
-          else
-            break
-          end
+          break unless data.length > length
+          data = data[length..-1]
         end
       end
 

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -34,8 +34,8 @@ module HTTP
     # @option opts [String] :uri
     def initialize(opts)
       @version  = opts.fetch(:version)
-      @uri      = HTTP::URI.parse(opts.fetch :uri) if opts.include? :uri
-      @status   = HTTP::Response::Status.new(opts.fetch :status)
+      @uri      = HTTP::URI.parse(opts.fetch(:uri)) if opts.include? :uri
+      @status   = HTTP::Response::Status.new(opts.fetch(:status))
       @headers  = HTTP::Headers.coerce(opts[:headers] || {})
 
       if opts.include?(:connection)
@@ -59,7 +59,7 @@ module HTTP
     # @!method to_s
     #   (see HTTP::Response::Body#to_s)
     def_delegator :body, :to_s
-    alias_method :to_str, :to_s
+    alias to_str to_s
 
     # @!method readpartial
     #   (see HTTP::Response::Body#readpartial)

--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -48,7 +48,7 @@ module HTTP
 
         @contents
       end
-      alias_method :to_str, :to_s
+      alias to_str to_s
 
       # Assert that the body is actively being streamed
       def stream!

--- a/lib/http/response/parser.rb
+++ b/lib/http/response/parser.rb
@@ -11,7 +11,7 @@ module HTTP
       def add(data)
         @parser << data
       end
-      alias_method :<<, :add
+      alias << add
 
       def headers?
         !!@headers

--- a/lib/http/response/status.rb
+++ b/lib/http/response/status.rb
@@ -28,7 +28,7 @@ module HTTP
 
           fail Error, "Can't coerce #{object.class}(#{object}) to #{self}"
         end
-        alias_method :[], :coerce
+        alias [] coerce
 
         private
 

--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -54,7 +54,7 @@ module HTTP
         perform_io { write_nonblock(data) }
       end
 
-      alias_method :<<, :write
+      alias << write
 
       private
 

--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -48,7 +48,7 @@ module HTTP
       def write(data)
         @socket.write(data)
       end
-      alias_method :<<, :write
+      alias << write
 
       # These cops can be re-eanbled after we go Ruby 2.0+ only
       # rubocop:disable Lint/UselessAccessModifier, Metrics/BlockNesting

--- a/lib/http/uri.rb
+++ b/lib/http/uri.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "addressable/uri"
 
 module HTTP

--- a/lib/http/version.rb
+++ b/lib/http/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module HTTP
   VERSION = "1.0.2".freeze
 end

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe HTTP::Client do
 
     it "accepts params within the provided URL" do
       expect(HTTP::Request).to receive(:new) do |opts|
-        expect(CGI.parse opts[:uri].query).to eq("foo" => %w(bar))
+        expect(CGI.parse(opts[:uri].query)).to eq("foo" => %w(bar))
       end
 
       client.get("http://example.com/?foo=bar")
@@ -118,7 +118,7 @@ RSpec.describe HTTP::Client do
 
     it "combines GET params from the URI with the passed in params" do
       expect(HTTP::Request).to receive(:new) do |opts|
-        expect(CGI.parse opts[:uri].query).to eq("foo" => %w(bar), "baz" => %w(quux))
+        expect(CGI.parse(opts[:uri].query)).to eq("foo" => %w(bar), "baz" => %w(quux))
       end
 
       client.get("http://example.com/?foo=bar", :params => {:baz => "quux"})
@@ -142,7 +142,7 @@ RSpec.describe HTTP::Client do
 
     it "does not corrupts index-less arrays" do
       expect(HTTP::Request).to receive(:new) do |opts|
-        expect(CGI.parse opts[:uri].query).to eq "a[]" => %w(b c), "d" => %w(e)
+        expect(CGI.parse(opts[:uri].query)).to eq "a[]" => %w(b c), "d" => %w(e)
       end
 
       client.get("http://example.com/?a[]=b&a[]=c", :params => {:d => "e"})

--- a/spec/lib/http/headers_spec.rb
+++ b/spec/lib/http/headers_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe HTTP::Headers do
     end
 
     it "fails with empty header name" do
-      expect { headers.add "", "foobar" }.
+      expect { headers.add("", "foobar") }.
         to raise_error HTTP::InvalidHeaderNameError
     end
 
@@ -122,29 +122,29 @@ RSpec.describe HTTP::Headers do
   end
 
   describe "#get" do
-    before { headers.set "Content-Type", "application/json" }
+    before { headers.set("Content-Type", "application/json") }
 
     it "returns array of associated values" do
-      expect(headers.get "Content-Type").to eq %w(application/json)
+      expect(headers.get("Content-Type")).to eq %w(application/json)
     end
 
     it "normalizes header name" do
-      expect(headers.get :content_type).to eq %w(application/json)
+      expect(headers.get(:content_type)).to eq %w(application/json)
     end
 
     context "when header does not exists" do
       it "returns empty array" do
-        expect(headers.get :accept).to eq []
+        expect(headers.get(:accept)).to eq []
       end
     end
 
     it "fails with empty header name" do
-      expect { headers.get "" }.
+      expect { headers.get("") }.
         to raise_error HTTP::InvalidHeaderNameError
     end
 
     it "fails with invalid header name" do
-      expect { headers.get "foo bar" }.
+      expect { headers.get("foo bar") }.
         to raise_error HTTP::InvalidHeaderNameError
     end
   end
@@ -453,15 +453,18 @@ RSpec.describe HTTP::Headers do
       let(:headers) { {"Set-Cookie" => "hoo=ray", "set-cookie" => "woo=hoo"} }
 
       it "adds all headers" do
-        expect(described_class.coerce(headers).to_a).to match_array([
-          %w(Set-Cookie hoo=ray),
-          %w(Set-Cookie woo=hoo)
-        ])
+        expect(described_class.coerce(headers).to_a).
+          to match_array(
+            [
+              %w(Set-Cookie hoo=ray),
+              %w(Set-Cookie woo=hoo)
+            ]
+          )
       end
     end
 
     it "is aliased as .[]" do
-      expect(described_class.method :coerce).to eq described_class.method(:[])
+      expect(described_class.method(:coerce)).to eq described_class.method(:[])
     end
   end
 end

--- a/spec/lib/http/response/status_spec.rb
+++ b/spec/lib/http/response/status_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe HTTP::Response::Status do
   describe ".coerce" do
     context "with String" do
       it "coerces reasons" do
-        expect(described_class.coerce "Bad request").to eq described_class.new 400
+        expect(described_class.coerce("Bad request")).to eq described_class.new 400
       end
 
       it "fails when reason is unknown" do
@@ -106,26 +106,26 @@ RSpec.describe HTTP::Response::Status do
 
     context "with Symbol" do
       it "coerces symbolized reasons" do
-        expect(described_class.coerce :bad_request).to eq described_class.new 400
+        expect(described_class.coerce(:bad_request)).to eq described_class.new 400
       end
 
       it "fails when symbolized reason is unknown" do
-        expect { described_class.coerce :foobar }.to raise_error HTTP::Error
+        expect { described_class.coerce(:foobar) }.to raise_error HTTP::Error
       end
     end
 
     context "with Numeric" do
       it "coerces as Fixnum code" do
-        expect(described_class.coerce 200.1).to eq described_class.new 200
+        expect(described_class.coerce(200.1)).to eq described_class.new 200
       end
     end
 
     it "fails if coercion failed" do
-      expect { described_class.coerce true }.to raise_error HTTP::Error
+      expect { described_class.coerce(true) }.to raise_error HTTP::Error
     end
 
     it "is aliased as `.[]`" do
-      expect(described_class.method :coerce).to eq described_class.method :[]
+      expect(described_class.method(:coerce)).to eq described_class.method :[]
     end
   end
 end

--- a/spec/lib/http/response_spec.rb
+++ b/spec/lib/http/response_spec.rb
@@ -86,11 +86,11 @@ RSpec.describe HTTP::Response do
     context "with explicitly given mime type" do
       let(:content_type) { "application/deadbeef" }
       it "ignores mime_type of response" do
-        expect(response.parse "application/json").to eq "foo" => "bar"
+        expect(response.parse("application/json")).to eq "foo" => "bar"
       end
 
       it "supports MIME type aliases" do
-        expect(response.parse :json).to eq "foo" => "bar"
+        expect(response.parse(:json)).to eq "foo" => "bar"
       end
     end
   end

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe HTTP do
 
                 let(:characters) { ("A".."Z").to_a }
                 let(:request_body) do
-                  (size + fuzzer).times.map { |i| characters[i % characters.length] }.join
+                  Array.new(size + fuzzer) { |i| characters[i % characters.length] }.join
                 end
 
                 it "returns a large body" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,12 @@
 require "simplecov"
 require "coveralls"
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-])
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
 
 SimpleCov.start do
   add_filter "/spec/"

--- a/spec/support/servers/runner.rb
+++ b/spec/support/servers/runner.rb
@@ -1,5 +1,5 @@
 module ServerRunner
-  def run_server(name, &_block)
+  def run_server(name)
     let! name do
       server = yield
 

--- a/spec/support/servers/runner.rb
+++ b/spec/support/servers/runner.rb
@@ -1,7 +1,7 @@
 module ServerRunner
-  def run_server(name, &block)
+  def run_server(name, &_block)
     let! name do
-      server = block.call
+      server = yield
 
       Thread.new { server.start }
 

--- a/spec/support/ssl_helper.rb
+++ b/spec/support/ssl_helper.rb
@@ -6,7 +6,7 @@ module SSLHelper
   CERTS_PATH = Pathname.new File.expand_path("../../../tmp/certs", __FILE__)
 
   class RootCertificate < ::CertificateAuthority::Certificate
-    EXTENSIONS = {"keyUsage" => {"usage" => %w(critical keyCertSign)}}
+    EXTENSIONS = {"keyUsage" => {"usage" => %w(critical keyCertSign)}}.freeze
 
     def initialize
       super()


### PR DESCRIPTION
Includes a lot more cops for frozen string literals and constants which seem nice, particularly on Ruby 2.3+