### PR TITLE
Remove exception wrappers from per_operation.rb

### DIFF
--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -59,12 +59,7 @@ module HTTP
         # Read data from the socket
         def readpartial(size)
           loop do
-            # JRuby may still raise exceptions on SSL sockets even though
-            # we explicitly specify `:exception => false`
-            result = rescue_readable do
-              @socket.read_nonblock(size, :exception => false)
-            end
-
+            result = @socket.read_nonblock(size, :exception => false)
             if result.nil?
               return :eof
             elsif result != :wait_readable
@@ -80,12 +75,7 @@ module HTTP
         # Write data to the socket
         def write(data)
           loop do
-            # JRuby may still raise exceptions on SSL sockets even though
-            # we explicitly specify `:exception => false`
-            result = rescue_writable do
-              @socket.write_nonblock(data, :exception => false)
-            end
-
+            result = @socket.write_nonblock(data, :exception => false)
             return result unless result == :wait_writable
 
             unless @socket.to_io.wait_writable(write_timeout)


### PR DESCRIPTION
I started out reverting the changes to this file back to the version
@ixti bisected as being the last good one.

I left in the *actual* code that replaced IO.select with io/wait. And
I seem to have come upon the same thing @ixti did here:

https://github.com/httprb/http/commit/9e1e100d89e365600010859ea8c87400a766c29b

I'll have to check the behavior on JRuby, and am uncertain what sequence
of events causes the rescue_readable call to be an issue, but I think this
both lets us keep io/wait and at least has the same semantics as before.