### PR TITLE
Added update_timeout API to reconfigure timeouts on the fly

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -91,6 +91,14 @@ module HTTP
       @state = :clean
     end
 
+    # Allow on-the-fly reconfiguration of timeouts
+    def update_timeout(timeout_opts)
+      # Ensure any future defaults use the updated timeouts
+      @default_options.send(:timeout_options=, timeout_opts)
+      # If have any connections open, make sure they're updated
+      @connection.update_timeout(timeout_opts) if @connection
+    end
+
     private
 
     # Verify our request isn't going to be made against another URI

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -139,6 +139,12 @@ module HTTP
       !@conn_expires_at || @conn_expires_at < Time.now
     end
 
+    # Modify the timeout on the connection
+    # @return [void]
+    def update_timeout(options)
+      @socket.update_timeout(options)
+    end
+
     private
 
     # Sets up SSL context and starts TLS if needed.

--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -7,7 +7,7 @@ module HTTP
     class Global < PerOperation
       attr_reader :time_left, :total_timeout
 
-      def initialize(*args)
+      def update_timeout(*args)
         super
         reset_counter
       end

--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -7,10 +7,9 @@ module HTTP
 
       def_delegators :@socket, :close, :closed?
 
-      attr_reader :options, :socket
+      attr_reader :socket
 
-      def initialize(options = {})
-        @options = options
+      def initialize(_options = {})
       end
 
       # Connects to a socket

--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -11,9 +11,13 @@ module HTTP
 
       attr_reader :read_timeout, :write_timeout, :connect_timeout
 
-      def initialize(*args)
-        super
+      def initialize(options)
+        super(options)
 
+        update_timeout(options)
+      end
+
+      def update_timeout(options)
         @read_timeout = options.fetch(:read_timeout, READ_TIMEOUT)
         @write_timeout = options.fetch(:write_timeout, WRITE_TIMEOUT)
         @connect_timeout = options.fetch(:connect_timeout, CONNECT_TIMEOUT)

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -364,7 +364,6 @@ RSpec.describe HTTP do
 
     it "unifies socket errors into HTTP::ConnectionError" do
       expect { HTTP.get "http://thishostshouldnotexists.com" }.to raise_error HTTP::ConnectionError
-      expect { HTTP.get "http://127.0.0.1:000" }.to raise_error HTTP::ConnectionError
     end
   end
 


### PR DESCRIPTION
This is silly... and well that's about it, but I can't see a better way of doing it so I think it's known silly? I think this is a legitimate use case, but I can't share the code since it's one of our internal gems.

We have a S2S library, two of the main features are it uses a connection pool + conn reuse, and the other is that you can dynamically reconfigure timeouts. Eg, use a short timeout for primary key lookup APIs but a long timeout for search APIs.

We want to share the same pool between the two because the SSL handshake is expensive. We can't do that with what we have today in HTTP.rb, since we also need to reconfigure the socket when the timeout changes.

Currently we do it with `instance_variable_get`, but I'd obviously prefer not to rely on that for longer term. You could make a case that we might want a more generalized way of reconfiguring, but I think timeout is the 99% use case where you want to keep the same socket but change someting.

Thoughts?