### PR TITLE
Use object composition rather than inheritance for HTTP::URI

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -141,7 +141,7 @@ module HTTP
       return p_client unless block_given?
       yield p_client
     ensure
-      p_client.close unless p_client.nil?
+      p_client.close if p_client
     end
 
     # Make a request through an HTTP proxy

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -141,7 +141,7 @@ module HTTP
       return p_client unless block_given?
       yield p_client
     ensure
-      p_client.close
+      p_client.close unless p_client.nil?
     end
 
     # Make a request through an HTTP proxy

--- a/lib/http/uri.rb
+++ b/lib/http/uri.rb
@@ -2,12 +2,95 @@
 require "addressable/uri"
 
 module HTTP
-  class URI < Addressable::URI
+  class URI
+    extend Forwardable
+
+    def_delegators :@uri, :scheme, :normalized_scheme, :scheme=
+    def_delegators :@uri, :user, :normalized_user, :user=
+    def_delegators :@uri, :password, :normalized_password, :password=
+    def_delegators :@uri, :host, :normalized_host, :host=
+    def_delegators :@uri, :authority, :normalized_authority, :authority=
+    def_delegators :@uri, :origin, :origin=
+    def_delegators :@uri, :port, :normalized_port, :port=, :default_port
+    def_delegators :@uri, :path, :normalized_path, :path=
+    def_delegators :@uri, :query, :normalized_query, :query=
+    def_delegators :@uri, :request_uri, :request_uri=
+    def_delegators :@uri, :fragment, :normalized_fragment, :fragment=
+    def_delegators :@uri, :omit, :join, :normalize
+
     # @private
     HTTP_SCHEME = "http".freeze
 
     # @private
     HTTPS_SCHEME = "https".freeze
+
+    # Parse the given URI string, returning an HTTP::URI object
+    #
+    # @param [HTTP::URI, String, #to_str] :uri to parse
+    #
+    # @return [HTTP::URI] new URI instance
+    def self.parse(uri)
+      return uri if uri.is_a?(self)
+
+      new(Addressable::URI.parse(uri))
+    end
+
+    # Encodes key/value pairs as application/x-www-form-urlencoded
+    #
+    # @param [#to_hash, #to_ary] :form_values to encode
+    # @param [TrueClass, FalseClass] :sort should key/value pairs be sorted first?
+    #
+    # @return [String] encoded value
+    def self.form_encode(form_values, sort = false)
+      Addressable::URI.form_encode(form_values, sort)
+    end
+
+    # Creates an HTTP::URI instance from the given options
+    #
+    # @option [String, #to_str] :scheme URI scheme
+    # @option [String, #to_str] :user for basic authentication
+    # @option [String, #to_str] :password for basic authentication
+    # @option [String, #to_str] :host name component
+    # @option [String, #to_str] :port network port to connect to
+    # @option [String, #to_str] :path component to request
+    # @option [String, #to_str] :query component distinct from path
+    # @option [String, #to_str] :fragment component at the end of the URI
+    #
+    # @return [HTTP::URI] new URI instance
+    def initialize(options_or_uri = {})
+      case options_or_uri
+      when Hash
+        @uri = Addressable::URI.new(options_or_uri)
+      when Addressable::URI
+        @uri = options_or_uri
+      else fail TypeError, "expected Hash for options, got #{options_or_uri.class}"
+      end
+    end
+
+    # Are these URI objects equal? Normalizes both URIs prior to comparison
+    #
+    # @param [Object] :other URI to compare this one with
+    #
+    # @return [TrueClass, FalseClass] are the URIs equivalent (after normalization)?
+    def ==(other)
+      other.is_a?(URI) && normalize.to_s == other.normalize.to_s
+    end
+
+    # Are these URI objects equal? Does NOT normalizes both URIs prior to comparison
+    #
+    # @param [Object] :other URI to compare this one with
+    #
+    # @return [TrueClass, FalseClass] are the URIs equivalent?
+    def eql?(other)
+      other.is_a?(URI) && to_s == other.to_s
+    end
+
+    # Hash value based off the normalized form of a URI
+    #
+    # @return [Integer] A hash of the URI
+    def hash
+      @hash ||= to_s.hash * -1
+    end
 
     # @return [True] if URI is HTTP
     # @return [False] otherwise
@@ -21,9 +104,17 @@ module HTTP
       HTTPS_SCHEME == scheme
     end
 
+    # Convert an HTTP::URI to a String
+    #
+    # @return [String] URI serialized as a String
+    def to_s
+      @uri.to_s
+    end
+    alias to_str to_s
+
     # @return [String] human-readable representation of URI
     def inspect
-      format("#<%s:%#0x URI:%s>", self.class, object_id, to_s)
+      format("#<%s:0x%014x URI:%s>", self.class.name, object_id << 1, to_s)
     end
   end
 end

--- a/lib/http/uri.rb
+++ b/lib/http/uri.rb
@@ -11,7 +11,7 @@ module HTTP
     def_delegators :@uri, :host, :normalized_host, :host=
     def_delegators :@uri, :authority, :normalized_authority, :authority=
     def_delegators :@uri, :origin, :origin=
-    def_delegators :@uri, :port, :normalized_port, :port=, :default_port
+    def_delegators :@uri, :normalized_port, :port=
     def_delegators :@uri, :path, :normalized_path, :path=
     def_delegators :@uri, :query, :normalized_query, :query=
     def_delegators :@uri, :request_uri, :request_uri=
@@ -90,6 +90,13 @@ module HTTP
     # @return [Integer] A hash of the URI
     def hash
       @hash ||= to_s.hash * -1
+    end
+
+    # Port number, either as specified or the default if unspecified
+    #
+    # @return [Integer] port number
+    def port
+      @uri.port || @uri.default_port
     end
 
     # @return [True] if URI is HTTP

--- a/spec/lib/http/uri_spec.rb
+++ b/spec/lib/http/uri_spec.rb
@@ -1,9 +1,20 @@
 RSpec.describe HTTP::URI do
-  let(:example_uri_string) { "http://example.com" }
+  let(:example_http_uri_string)  { "http://example.com" }
+  let(:example_https_uri_string) { "https://example.com" }
 
-  subject(:uri) { described_class.parse(example_uri_string) }
+  subject(:http_uri)  { described_class.parse(example_http_uri_string) }
+  subject(:https_uri) { described_class.parse(example_https_uri_string) }
 
   it "knows URI schemes" do
-    expect(uri.scheme).to eq "http"
+    expect(http_uri.scheme).to eq "http"
+    expect(https_uri.scheme).to eq "https"
+  end
+
+  it "sets default ports for HTTP URIs" do
+    expect(http_uri.port).to eq 80
+  end
+
+  it "sets default ports for HTTPS URIs" do
+    expect(https_uri.port).to eq 443
   end
 end

--- a/spec/lib/http/uri_spec.rb
+++ b/spec/lib/http/uri_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe HTTP::URI do
+  let(:example_uri_string) { "http://example.com" }
+
+  subject(:uri) { described_class.parse(example_uri_string) }
+
+  it "knows URI schemes" do
+    expect(uri.scheme).to eq "http"
+  end
+end


### PR DESCRIPTION
The Addressable gem has been the source of a number of bugs and performance problems (e.g. #206, #297, #323)

Perhaps in the future it might be worth avoiding using it where `::URI` would suffice, or getting rid of it entirely, but as things stand `Addressable::URI` is the parent class for `HTTP::URI`, which prevents us from doing that without making a breaking release of the library.

This replaces inheritance with object composition: `Forwardable` is used to delegate an explicit set of methods to `Addressable::URI`. This should make it easier to work around Addressable bugs or
potentially even use `::URI` as the internal representation when URIs are simple enough.