### PR TITLE
Support custom CONNECT headers (both request and response) during HTTPS proxy requests

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -153,8 +153,10 @@ module HTTP
       proxy_hash[:proxy_port]     = proxy[1] if proxy[1].is_a?(Integer)
       proxy_hash[:proxy_username] = proxy[2] if proxy[2].is_a?(String)
       proxy_hash[:proxy_password] = proxy[3] if proxy[3].is_a?(String)
+      proxy_hash[:proxy_headers]  = proxy[2] if proxy[2].is_a?(Hash)
+      proxy_hash[:proxy_headers]  = proxy[4] if proxy[4].is_a?(Hash)
 
-      raise(RequestError, "invalid HTTP proxy: #{proxy_hash}") unless [2, 4].include?(proxy_hash.keys.size)
+      raise(RequestError, "invalid HTTP proxy: #{proxy_hash}") unless (2..5).cover?(proxy_hash.keys.size)
 
       branch default_options.with_proxy(proxy_hash)
     end

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -68,12 +68,13 @@ module HTTP
       end
 
       res = Response.new(
-        :status     => @connection.status_code,
-        :version    => @connection.http_version,
-        :headers    => @connection.headers,
-        :connection => @connection,
-        :encoding   => options.encoding,
-        :uri        => req.uri
+        :status        => @connection.status_code,
+        :version       => @connection.http_version,
+        :headers       => @connection.headers,
+        :proxy_headers => @connection.proxy_response_headers,
+        :connection    => @connection,
+        :encoding      => options.encoding,
+        :uri           => req.uri
       )
 
       @connection.finish_response if req.verb == :head

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -19,6 +19,9 @@ module HTTP
     # HTTP/1.1
     HTTP_1_1 = "1.1".freeze
 
+    # Returned after HTTP CONNECT (via proxy)
+    attr_reader :proxy_response_headers
+
     # @param [HTTP::Request] req
     # @param [HTTP::Options] options
     # @raise [HTTP::ConnectionError] when failed to connect
@@ -164,6 +167,7 @@ module HTTP
       @pending_response = true
 
       read_headers!
+      @proxy_response_headers = @parser.headers
 
       if @parser.status_code != 200
         @failed_proxy_connect = true

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -106,7 +106,7 @@ module HTTP
 
     # Stream the request to a socket
     def stream(socket)
-      include_proxy_authorization_header if using_authenticated_proxy? && !@uri.https?
+      include_proxy_headers if using_proxy? && !@uri.https?
       Request::Writer.new(socket, body, headers, headline).stream
     end
 
@@ -118,6 +118,11 @@ module HTTP
     # Is this request using an authenticated proxy?
     def using_authenticated_proxy?
       proxy && proxy.keys.size >= 4
+    end
+
+    def include_proxy_headers
+      headers.merge!(proxy[:proxy_headers]) if proxy.key?(:proxy_headers)
+      include_proxy_authorization_header if using_authenticated_proxy?
     end
 
     # Compute and add the Proxy-Authorization header

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -117,7 +117,7 @@ module HTTP
 
     # Is this request using an authenticated proxy?
     def using_authenticated_proxy?
-      proxy && proxy.keys.size == 4
+      proxy && proxy.keys.size >= 4
     end
 
     # Compute and add the Proxy-Authorization header
@@ -154,7 +154,7 @@ module HTTP
       )
 
       connect_headers[Headers::PROXY_AUTHORIZATION] = proxy_authorization_header if using_authenticated_proxy?
-
+      connect_headers.merge!(proxy[:proxy_headers]) if proxy.key?(:proxy_headers)
       connect_headers
     end
 

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -23,20 +23,25 @@ module HTTP
     # @return [URI, nil]
     attr_reader :uri
 
+    # @return [Hash]
+    attr_reader :proxy_headers
+
     # Inits a new instance
     #
     # @option opts [Integer] :status Status code
     # @option opts [String] :version HTTP version
     # @option opts [Hash] :headers
+    # @option opts [Hash] :proxy_headers
     # @option opts [HTTP::Connection] :connection
     # @option opts [String] :encoding Encoding to use when reading body
     # @option opts [String] :body
     # @option opts [String] :uri
     def initialize(opts)
-      @version  = opts.fetch(:version)
-      @uri      = HTTP::URI.parse(opts.fetch(:uri)) if opts.include? :uri
-      @status   = HTTP::Response::Status.new(opts.fetch(:status))
-      @headers  = HTTP::Headers.coerce(opts[:headers] || {})
+      @version       = opts.fetch(:version)
+      @uri           = HTTP::URI.parse(opts.fetch(:uri)) if opts.include? :uri
+      @status        = HTTP::Response::Status.new(opts.fetch(:status))
+      @headers       = HTTP::Headers.coerce(opts[:headers] || {})
+      @proxy_headers = HTTP::Headers.coerce(opts[:proxy_headers] || {})
 
       if opts.include?(:connection)
         connection = opts.fetch(:connection)


### PR DESCRIPTION
Note: Just throwing this idea out there -- I implemented these changes for my own use case, but I'm happy to rework the implementation if it's not deemed suitable for merging. Let me know.

### The Issue

Some proxies accept custom headers, for things like switching IPs, excluding certain IPs, or specifying custom behaviors (like retrying requests when certain codes are returned). Over normal HTTP, these can be sent along with the rest of your headers, and the proxy will filter the headers before passing the request along. Likewise, the proxy might inject a custom header into the response (such as one indicating the IP your request was passed through).

**However**, everything changes over a secured connection. When connecting to a proxy over HTTPS, this gem makes use of HTTP tunneling via the 'CONNECT'  method. The underlying request and response are encrypted. As a result, the proxy is unable to read any headers you send with the underlying request or inject headers into the underlying response.

So adding custom proxy-specific headers to a HTTPS request looks something like this:

```
CONNECT example.com:1234 HTTP/1.1
Proxy-Authorization: Digest [your auth digest]
X-My-Custom-Header: Yes

<Your Underlying Request Goes Here>
```

And a response from the proxy (with a custom header) looks like this:

```
HTTP/1.1 200 Connection established
X-Custom-Proxy-Response: Success

<The Underlying Response Appears Here>
```

**The problem** is that, aside from `Proxy-Authorization`, this gem does not support adding custom headers (like `X-My-Custom-Header` and `X-Custom-Proxy-Response` above).

### The Change(s)

This PR adds a parameter to the `via` method which allows you to specify custom headers intended for use by the proxy:

```ruby
HTTP.via("proxy-hostname.local", 8080, 'x-retry-if' => 502)
    .get("https://example.com/resource")
HTTP.via("proxy-hostname.local", 8080, USERNAME, PASSWORD, 'x-use-ip' => '123.456.11.11')
    .get("https://example.com/resource")
```

*Note that if the underlying request is 'http' instead of 'https', there is no `CONNECT` tunneling, so the proxy-specific headers will be merged into the requests's primary headers.*

Similarly, if the proxy returns any custom headers (as shown above), they are made available as follows:

```ruby
response = HTTP.via("proxy-hostname.local", 8080).get("https://example.com/resource")

response.proxy_headers
# => { 'x-ip-used' => '123.456.42.42' }
```

*Note: I considered transparently merging these into the main request headers, but I worried that this would cause strange behavior. Either a proxy could overwrite a header you expect from the remote server, or the remote server could overwrite a header you expect from the proxy, and I wasn't sure how to handle these cases. If you have any suggestions I'd be happy to rework the behavior.*

### Questions?

Does all of this make sense? Let me know if you have any questions, ideas, suggestions, etc.