### PR TITLE
Separate status codes by type and add helper methods to check status

### DIFF
--- a/lib/http/response/status.rb
+++ b/lib/http/response/status.rb
@@ -83,6 +83,36 @@ module HTTP
         "#{code} #{reason}".strip
       end
 
+      # Check if status code is informational (1XX)
+      # @return [Boolean]
+      def informational?
+        INFORMATIONAL.keys.include?(code)
+      end
+
+      # Check if status code is successful (2XX)
+      # @return [Boolean]
+      def success?
+        SUCCESSFUL.keys.include?(code)
+      end
+
+      # Check if status code is redirection (3XX)
+      # @return [Boolean]
+      def redirect?
+        REDIRECTION.keys.include?(code)
+      end
+
+      # Check if status code is client error (4XX)
+      # @return [Boolean]
+      def client_error?
+        CLIENT_ERROR.keys.include?(code)
+      end
+
+      # Check if status code is server error (5XX)
+      # @return [Boolean]
+      def server_error?
+        SERVER_ERROR.keys.include?(code)
+      end
+
       # Symbolized {#reason}
       #
       # @return [nil] unless code is well-known (see REASONS)

--- a/lib/http/response/status/reasons.rb
+++ b/lib/http/response/status/reasons.rb
@@ -13,10 +13,13 @@ module HTTP
       #   REASONS[414] # => "Request-URI Too Long"
       #
       # @return [Hash<Fixnum => String>]
-      REASONS = {
+      INFORMATIONAL = {
         100 => "Continue",
         101 => "Switching Protocols",
-        102 => "Processing",
+        102 => "Processing"
+      }.each { |_, v| v.freeze }.freeze
+
+      SUCCESSFUL = {
         200 => "OK",
         201 => "Created",
         202 => "Accepted",
@@ -26,7 +29,10 @@ module HTTP
         206 => "Partial Content",
         207 => "Multi-Status",
         208 => "Already Reported",
-        226 => "IM Used",
+        226 => "IM Used"
+      }.each { |_, v| v.freeze }.freeze
+
+      REDIRECTION = {
         300 => "Multiple Choices",
         301 => "Moved Permanently",
         302 => "Found",
@@ -34,7 +40,10 @@ module HTTP
         304 => "Not Modified",
         305 => "Use Proxy",
         307 => "Temporary Redirect",
-        308 => "Permanent Redirect",
+        308 => "Permanent Redirect"
+      }.each { |_, v| v.freeze }.freeze
+
+      CLIENT_ERROR = {
         400 => "Bad Request",
         401 => "Unauthorized",
         402 => "Payment Required",
@@ -61,7 +70,10 @@ module HTTP
         428 => "Precondition Required",
         429 => "Too Many Requests",
         431 => "Request Header Fields Too Large",
-        451 => "Unavailable For Legal Reasons",
+        451 => "Unavailable For Legal Reasons"
+      }.each { |_, v| v.freeze }.freeze
+
+      SERVER_ERROR = {
         500 => "Internal Server Error",
         501 => "Not Implemented",
         502 => "Bad Gateway",
@@ -74,6 +86,14 @@ module HTTP
         510 => "Not Extended",
         511 => "Network Authentication Required"
       }.each { |_, v| v.freeze }.freeze
+
+      REASONS = [
+        INFORMATIONAL,
+        SUCCESSFUL,
+        REDIRECTION,
+        CLIENT_ERROR,
+        SERVER_ERROR
+      ].inject(&:merge).each { |_, v| v.freeze }.freeze
     end
   end
 end

--- a/spec/lib/http/response/status_spec.rb
+++ b/spec/lib/http/response/status_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe HTTP::Response::Status do
         context 'with informational status code: #{code}' do
           let(:code) { #{code} }
           it { is_expected.to be true }
-          it { is_expected.to be_frozen }
         end
       RUBY
     end
@@ -68,7 +67,6 @@ RSpec.describe HTTP::Response::Status do
         context 'with successful status code: #{code}' do
           let(:code) { #{code} }
           it { is_expected.to be true }
-          it { is_expected.to be_frozen }
         end
       RUBY
     end
@@ -95,7 +93,6 @@ RSpec.describe HTTP::Response::Status do
         context 'with redirection status code: #{code}' do
           let(:code) { #{code} }
           it { is_expected.to be true }
-          it { is_expected.to be_frozen }
         end
       RUBY
     end
@@ -122,7 +119,6 @@ RSpec.describe HTTP::Response::Status do
         context 'with client error status code: #{code}' do
           let(:code) { #{code} }
           it { is_expected.to be true }
-          it { is_expected.to be_frozen }
         end
       RUBY
     end
@@ -149,7 +145,6 @@ RSpec.describe HTTP::Response::Status do
         context 'with server error status code: #{code}' do
           let(:code) { #{code} }
           it { is_expected.to be true }
-          it { is_expected.to be_frozen }
         end
       RUBY
     end

--- a/spec/lib/http/response/status_spec.rb
+++ b/spec/lib/http/response/status_spec.rb
@@ -34,6 +34,141 @@ RSpec.describe HTTP::Response::Status do
     end
   end
 
+  describe "#informational?" do
+    subject { described_class.new(code).informational? }
+    described_class::INFORMATIONAL.each do |code, _reason|
+      class_eval <<-RUBY
+        context 'with informational status code: #{code}' do
+          let(:code) { #{code} }
+          it { is_expected.to be true }
+          it { is_expected.to be_frozen }
+        end
+      RUBY
+    end
+
+    context "with non-informational code" do
+      other_codes = described_class::REASONS.reject do |code, _reason|
+        described_class::INFORMATIONAL.keys.include?(code)
+      end
+      other_codes.each do |code, _reason|
+        class_eval <<-RUBY
+          context 'with status code: #{code}' do
+            let(:code) { #{code} }
+            it { is_expected.to be false }
+          end
+        RUBY
+      end
+    end
+  end
+
+  describe "#success?" do
+    subject { described_class.new(code).success? }
+    described_class::SUCCESSFUL.each do |code, _reason|
+      class_eval <<-RUBY
+        context 'with successful status code: #{code}' do
+          let(:code) { #{code} }
+          it { is_expected.to be true }
+          it { is_expected.to be_frozen }
+        end
+      RUBY
+    end
+
+    context "with non-successful code" do
+      other_codes = described_class::REASONS.reject do |code, _reason|
+        described_class::SUCCESSFUL.keys.include?(code)
+      end
+      other_codes.each do |code, _reason|
+        class_eval <<-RUBY
+          context 'with status code: #{code}' do
+            let(:code) { #{code} }
+            it { is_expected.to be false }
+          end
+        RUBY
+      end
+    end
+  end
+
+  describe "#redirect?" do
+    subject { described_class.new(code).redirect? }
+    described_class::REDIRECTION.each do |code, _reason|
+      class_eval <<-RUBY
+        context 'with redirection status code: #{code}' do
+          let(:code) { #{code} }
+          it { is_expected.to be true }
+          it { is_expected.to be_frozen }
+        end
+      RUBY
+    end
+
+    context "with non-redirection code" do
+      other_codes = described_class::REASONS.reject do |code, _reason|
+        described_class::REDIRECTION.keys.include?(code)
+      end
+      other_codes.each do |code, _reason|
+        class_eval <<-RUBY
+          context 'with status code: #{code}' do
+            let(:code) { #{code} }
+            it { is_expected.to be false }
+          end
+        RUBY
+      end
+    end
+  end
+
+  describe "#client_error?" do
+    subject { described_class.new(code).client_error? }
+    described_class::CLIENT_ERROR.each do |code, _reason|
+      class_eval <<-RUBY
+        context 'with client error status code: #{code}' do
+          let(:code) { #{code} }
+          it { is_expected.to be true }
+          it { is_expected.to be_frozen }
+        end
+      RUBY
+    end
+
+    context "with non-client error code" do
+      other_codes = described_class::REASONS.reject do |code, _reason|
+        described_class::CLIENT_ERROR.keys.include?(code)
+      end
+      other_codes.each do |code, _reason|
+        class_eval <<-RUBY
+          context 'with status code: #{code}' do
+            let(:code) { #{code} }
+            it { is_expected.to be false }
+          end
+        RUBY
+      end
+    end
+  end
+
+  describe "#server_error?" do
+    subject { described_class.new(code).server_error? }
+    described_class::SERVER_ERROR.each do |code, _reason|
+      class_eval <<-RUBY
+        context 'with server error status code: #{code}' do
+          let(:code) { #{code} }
+          it { is_expected.to be true }
+          it { is_expected.to be_frozen }
+        end
+      RUBY
+    end
+
+    context "with non-server error" do
+      other_codes = described_class::REASONS.reject do |code, _reason|
+        described_class::SERVER_ERROR.keys.include?(code)
+      end
+      other_codes.each do |code, _reason|
+        class_eval <<-RUBY
+          context 'with status code: #{code}' do
+            let(:code) { #{code} }
+            it { is_expected.to be false }
+          end
+        RUBY
+      end
+    end
+  end
+
   describe "#to_sym" do
     subject { described_class.new(code).to_sym }
 


### PR DESCRIPTION
* Break status codes up by type
* Add status boolean helper methods to check status types.
example usage:
```
HTTP.get('http://google.com').status.informational?
HTTP.get('http://google.com').status.success?
HTTP.get('http://google.com').status.redirect?
HTTP.get('http://google.com').status.client_error?
HTTP.get('http://google.com').status.server_error?
```
returns true or false, depending on status code type