### PR TITLE
Headline shouldn't include host for https requests through proxy.

### DIFF
--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -142,7 +142,7 @@ module HTTP
 
     # Compute HTTP request header for direct or proxy request
     def headline
-      request_uri = using_proxy? ? uri : uri.omit(:scheme, :authority)
+      request_uri = (using_proxy? && !uri.https?) ? uri : uri.omit(:scheme, :authority)
       "#{verb.to_s.upcase} #{request_uri.omit :fragment} HTTP/#{version}"
     end
 

--- a/spec/lib/http/request_spec.rb
+++ b/spec/lib/http/request_spec.rb
@@ -202,6 +202,12 @@ RSpec.describe HTTP::Request do
     context "with proxy" do
       let(:proxy) { {:user => "user", :pass => "pass"} }
       it { is_expected.to eq "GET http://example.com/foo?bar=baz HTTP/1.1" }
+
+      context "and HTTPS uri" do
+        let(:request_uri) { "https://example.com/foo?bar=baz" }
+
+        it { is_expected.to eq "GET /foo?bar=baz HTTP/1.1" }
+      end
     end
   end
 end


### PR DESCRIPTION
I think this actually fixes #206 (at least one of the later comments in it)