### PR TITLE
Default to sane cipher suite

### DIFF
--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -45,7 +45,7 @@ module HTTP
         :socket_class       => self.class.default_socket_class,
         :nodelay            => false,
         :ssl_socket_class   => self.class.default_ssl_socket_class,
-        :ssl                => {},
+        :ssl                => { :ciphers => 'HIGH:!SSLv2:!aNULL:!eNULL:!3DES' },
         :keep_alive_timeout => 5,
         :headers            => {},
         :cookies            => {},


### PR DESCRIPTION
http.rb defaults to insecure ciphers like RC4, allowing attackers to decrypt encrypted data.

When tested against https://www.howsmyssl.com/a/check, the api returns this for http.rb:

```
HTTP.get('https://www.howsmyssl.com/a/check').body.to_s

{
  "given_cipher_suites": [
    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
    "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
    "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
    "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
    "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
    "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
    "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
    "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
    "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
    "TLS_RSA_WITH_AES_128_GCM_SHA256",
    "TLS_RSA_WITH_AES_256_GCM_SHA384",
    "TLS_RSA_WITH_AES_128_CBC_SHA256",
    "TLS_RSA_WITH_AES_256_CBC_SHA256",
    "TLS_RSA_WITH_AES_128_CBC_SHA",
    "TLS_RSA_WITH_AES_256_CBC_SHA",
    "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
    "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
    "TLS_RSA_WITH_RC4_128_SHA",
    "TLS_EMPTY_RENEGOTIATION_INFO_SCSV"
  ],
  "ephemeral_keys_supported": true,
  "session_ticket_supported": true,
  "tls_compression_supported": false,
  "unknown_cipher_suite_supported": false,
  "beast_vuln": false,
  "able_to_detect_n_minus_one_splitting": false,
  "insecure_cipher_suites": {
    "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA": [
      "uses RC4 which has insecure biases in its output"
    ],
    "TLS_ECDHE_RSA_WITH_RC4_128_SHA": [
      "uses RC4 which has insecure biases in its output"
    ],
    "TLS_RSA_WITH_RC4_128_SHA": [
      "uses RC4 which has insecure biases in its output"
    ]
  },
  "tls_version": "TLS 1.2",
  "rating": "Bad"
}
```

This commit sets a default cipher suite and avoids using the RC4 encryption algorithm. For more information about RC4 deprecation, see https://tools.ietf.org/html/rfc7465. :smile_cat: 