### PR TITLE
Always use byte methods when writing/slicing the write buffer

### DIFF
--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -95,8 +95,8 @@ module HTTP
       def write(data)
         until data.empty?
           length = @socket.write(data)
-          break unless data.length > length
-          data = data[length..-1]
+          break unless data.bytesize > length
+          data = data.byteslice(length..-1)
         end
       end
 

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -64,7 +64,19 @@ RSpec.describe HTTP do
                   response = client.post("#{dummy.endpoint}/echo-body", :body => request_body)
 
                   expect(response.body.to_s).to eq(request_body)
-                  expect(response.headers["Content-Length"].to_i).to eq(request_body.length)
+                  expect(response.headers["Content-Length"].to_i).to eq(request_body.bytesize)
+                end
+
+                context "when bytesize != length" do
+                  let(:characters) { ("A".."Z").to_a.push("“") }
+
+                  it "returns a large body" do
+                    body = {:data => request_body}
+                    response = client.post("#{dummy.endpoint}/echo-body", :json => body)
+
+                    expect(CGI.unescape(response.body.to_s)).to eq(body.to_json)
+                    expect(response.headers["Content-Length"].to_i).to eq(body.to_json.bytesize)
+                  end
                 end
               end
             end


### PR DESCRIPTION
This doesn't actually fail in our tests, because the test server we use apparently is broken too. I'm adding it more for posterity than it helps prevent regressions. I tested it against Passenger where it does fix it though!

We send `Content-Length` using `bytesize`, but we sliced the buffers using `length`. When those don't match up, things blow up because we send corrupted data. This would only happen if you're sending enough data that it can't be buffered into one `write` call.