### PR TITLE
do not enforce hash rockets, prefer 1.9 hash literal syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,9 +55,6 @@ Style/EachWithObject:
 Style/Encoding:
   Enabled: false
 
-Style/HashSyntax:
-  EnforcedStyle: hash_rockets
-
 Style/Lambda:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gem "rake"
 group :development do
   gem "celluloid-io"
   gem "guard"
-  gem "guard-rspec", :require => false
-  gem "nokogiri", :require => false
+  gem "guard-rspec", require: false
+  gem "nokogiri", require: false
   gem "pry"
 
   platforms :ruby_19, :ruby_20 do
@@ -24,7 +24,7 @@ group :test do
   gem "rspec",     "~> 3.0"
   gem "rspec-its"
   gem "yardstick"
-  gem "certificate_authority", :require => false
+  gem "certificate_authority", require: false
 end
 
 group :doc do

--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,6 @@
 # More info at https://github.com/guard/guard#readme
 
-guard :rspec, :cmd => "GUARD_RSPEC=1 bundle exec rspec --no-profile" do
+guard :rspec, cmd: "GUARD_RSPEC=1 bundle exec rspec --no-profile" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new
 
-task :test => :spec
+task test: :spec
 
 begin
   require "rubocop/rake_task"
@@ -68,4 +68,4 @@ task :generate_status_codes do
   end
 end
 
-task :default => [:spec, :rubocop, :verify_measurements]
+task default: [:spec, :rubocop, :verify_measurements]

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -19,7 +19,7 @@ module HTTP
   extend Chainable
 
   class << self
-    # HTTP[:accept => 'text/html'].get(...)
+    # HTTP[accept: 'text/html'].get(...)
     alias [] headers
   end
 end

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -102,8 +102,8 @@ module HTTP
       end
 
       branch default_options.merge(
-        :timeout_class => klass,
-        :timeout_options => options
+        timeout_class: klass,
+        timeout_options: options
       )
     end
 

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -34,11 +34,11 @@ module HTTP
       proxy   = opts.proxy
 
       req = HTTP::Request.new(
-        :verb    => verb,
-        :uri     => uri,
-        :headers => headers,
-        :proxy   => proxy,
-        :body    => body
+        verb:    verb,
+        uri:     uri,
+        headers: headers,
+        proxy:   proxy,
+        body:    body
       )
 
       res = perform(req, opts)
@@ -68,13 +68,13 @@ module HTTP
       end
 
       res = Response.new(
-        :status        => @connection.status_code,
-        :version       => @connection.http_version,
-        :headers       => @connection.headers,
-        :proxy_headers => @connection.proxy_response_headers,
-        :connection    => @connection,
-        :encoding      => options.encoding,
-        :uri           => req.uri
+        status:        @connection.status_code,
+        version:       @connection.http_version,
+        headers:       @connection.headers,
+        proxy_headers: @connection.proxy_response_headers,
+        connection:    @connection,
+        encoding:      options.encoding,
+        uri:           req.uri
       )
 
       @connection.finish_response if req.verb == :head

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -38,18 +38,18 @@ module HTTP
 
     def initialize(options = {})
       defaults = {
-        :response           => :auto,
-        :proxy              => {},
-        :timeout_class      => self.class.default_timeout_class,
-        :timeout_options    => {},
-        :socket_class       => self.class.default_socket_class,
-        :nodelay            => false,
-        :ssl_socket_class   => self.class.default_ssl_socket_class,
-        :ssl                => {},
-        :keep_alive_timeout => 5,
-        :headers            => {},
-        :cookies            => {},
-        :encoding           => nil
+        response:           :auto,
+        proxy:              {},
+        timeout_class:      self.class.default_timeout_class,
+        timeout_options:    {},
+        socket_class:       self.class.default_socket_class,
+        nodelay:            false,
+        ssl_socket_class:   self.class.default_ssl_socket_class,
+        ssl:                {},
+        keep_alive_timeout: 5,
+        headers:            {},
+        cookies:            {},
+        encoding:           nil
       }
 
       opts_w_defaults = defaults.merge(options)

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -49,10 +49,10 @@ module HTTP
 
     # Default ports of supported schemes
     PORTS = {
-      :http   => 80,
-      :https  => 443,
-      :ws     => 80,
-      :wss    => 443
+      http:   80,
+      https:  443,
+      ws:     80,
+      wss:    443
     }.freeze
 
     # Method is given as a lowercase symbol e.g. :get, :post
@@ -92,12 +92,12 @@ module HTTP
     # Returns new Request with updated uri
     def redirect(uri, verb = @verb)
       req = self.class.new(
-        :verb    => verb,
-        :uri     => @uri.join(uri),
-        :headers => headers,
-        :proxy   => proxy,
-        :body    => body,
-        :version => version
+        verb:    verb,
+        uri:     @uri.join(uri),
+        headers: headers,
+        proxy:   proxy,
+        body:    body,
+        version: version
       )
 
       req[Headers::HOST] = req.uri.host
@@ -195,11 +195,11 @@ module HTTP
       uri = HTTP::URI.parse uri
 
       HTTP::URI.new(
-        :scheme     => uri.normalized_scheme,
-        :authority  => uri.normalized_authority,
-        :path       => uri.normalized_path,
-        :query      => uri.query,
-        :fragment   => uri.normalized_fragment
+        scheme:     uri.normalized_scheme,
+        authority:  uri.normalized_authority,
+        path:       uri.normalized_path,
+        query:      uri.query,
+        fragment:   uri.normalized_fragment
       )
     end
   end

--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -69,11 +69,11 @@ module HTTP
         end
       else
         def read_nonblock(size)
-          @socket.read_nonblock(size, :exception => false)
+          @socket.read_nonblock(size, exception: false)
         end
 
         def write_nonblock(data)
-          @socket.write_nonblock(data, :exception => false)
+          @socket.write_nonblock(data, exception: false)
         end
       end
 

--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -59,7 +59,7 @@ module HTTP
         # Read data from the socket
         def readpartial(size)
           loop do
-            result = @socket.read_nonblock(size, :exception => false)
+            result = @socket.read_nonblock(size, exception: false)
 
             return :eof   if result.nil?
             return result if result != :wait_readable
@@ -73,7 +73,7 @@ module HTTP
         # Write data to the socket
         def write(data)
           loop do
-            result = @socket.write_nonblock(data, :exception => false)
+            result = @socket.write_nonblock(data, exception: false)
             return result unless result == :wait_writable
 
             unless IO.select(nil, [@socket], nil, write_timeout)

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -27,24 +27,24 @@ RSpec.describe HTTP::Client do
 
   def redirect_response(location, status = 302)
     HTTP::Response.new(
-      :status  => status,
-      :version => "1.1",
-      :headers => {"Location" => location},
-      :body    => ""
+      status:  status,
+      version: "1.1",
+      headers: {"Location" => location},
+      body:    ""
     )
   end
 
   def simple_response(body, status = 200)
     HTTP::Response.new(
-      :status  => status,
-      :version => "1.1",
-      :body    => body
+      status:  status,
+      version: "1.1",
+      body:    body
     )
   end
 
   describe "following redirects" do
     it "returns response of new location" do
-      client = StubbedClient.new(:follow => true).stub(
+      client = StubbedClient.new(follow: true).stub(
         "http://example.com/"     => redirect_response("http://example.com/blog"),
         "http://example.com/blog" => simple_response("OK")
       )
@@ -53,7 +53,7 @@ RSpec.describe HTTP::Client do
     end
 
     it "prepends previous request uri scheme and host if needed" do
-      client = StubbedClient.new(:follow => true).stub(
+      client = StubbedClient.new(follow: true).stub(
         "http://example.com/"           => redirect_response("/index"),
         "http://example.com/index"      => redirect_response("/index.html"),
         "http://example.com/index.html" => simple_response("OK")
@@ -63,7 +63,7 @@ RSpec.describe HTTP::Client do
     end
 
     it "fails upon endless redirects" do
-      client = StubbedClient.new(:follow => true).stub(
+      client = StubbedClient.new(follow: true).stub(
         "http://example.com/" => redirect_response("/")
       )
 
@@ -72,7 +72,7 @@ RSpec.describe HTTP::Client do
     end
 
     it "fails if max amount of hops reached" do
-      client = StubbedClient.new(:follow => {:max_hops => 5}).stub(
+      client = StubbedClient.new(follow: {max_hops: 5}).stub(
         "http://example.com/"  => redirect_response("/1"),
         "http://example.com/1" => redirect_response("/2"),
         "http://example.com/2" => redirect_response("/3"),
@@ -88,7 +88,7 @@ RSpec.describe HTTP::Client do
 
     context "with non-ASCII URLs" do
       it "theoretically works like a charm" do
-        client = StubbedClient.new(:follow => true).stub(
+        client = StubbedClient.new(follow: true).stub(
           "http://example.com/"      => redirect_response("/könig"),
           "http://example.com/könig" => simple_response("OK")
         )
@@ -121,7 +121,7 @@ RSpec.describe HTTP::Client do
         expect(CGI.parse(opts[:uri].query)).to eq("foo" => %w(bar), "baz" => %w(quux))
       end
 
-      client.get("http://example.com/?foo=bar", :params => {:baz => "quux"})
+      client.get("http://example.com/?foo=bar", params: {baz: "quux"})
     end
 
     it "merges duplicate values" do
@@ -129,7 +129,7 @@ RSpec.describe HTTP::Client do
         expect(opts[:uri].query).to match(/^(a=1&a=2|a=2&a=1)$/)
       end
 
-      client.get("http://example.com/?a=1", :params => {:a => 2})
+      client.get("http://example.com/?a=1", params: {a: 2})
     end
 
     it "does not modifies query part if no params were given" do
@@ -145,7 +145,7 @@ RSpec.describe HTTP::Client do
         expect(CGI.parse(opts[:uri].query)).to eq "a[]" => %w(b c), "d" => %w(e)
       end
 
-      client.get("http://example.com/?a[]=b&a[]=c", :params => {:d => "e"})
+      client.get("http://example.com/?a[]=b&a[]=c", params: {d: "e"})
     end
 
     it "properly encodes colons" do
@@ -153,7 +153,7 @@ RSpec.describe HTTP::Client do
         expect(opts[:uri].query).to eq "t=1970-01-01T00%3A00%3A00Z"
       end
 
-      client.get("http://example.com/", :params => {:t => "1970-01-01T00:00:00Z"})
+      client.get("http://example.com/", params: {t: "1970-01-01T00:00:00Z"})
     end
   end
 
@@ -166,7 +166,7 @@ RSpec.describe HTTP::Client do
         expect(opts[:body]).to eq '{"foo":"bar"}'
       end
 
-      client.get("http://example.com/", :json => {:foo => :bar})
+      client.get("http://example.com/", json: {foo: :bar})
     end
   end
 
@@ -186,7 +186,7 @@ RSpec.describe HTTP::Client do
 
     context "with explicitly given `Host` header" do
       let(:headers) { {"Host" => "another.example.com"} }
-      let(:client)  { described_class.new :headers => headers }
+      let(:client)  { described_class.new headers: headers }
 
       it "keeps `Host` header as is" do
         expect(client).to receive(:perform) do |req, _|
@@ -206,12 +206,12 @@ RSpec.describe HTTP::Client do
   end
 
   describe "working with SSL" do
-    run_server(:dummy_ssl) { DummyServer.new(:ssl => true) }
+    run_server(:dummy_ssl) { DummyServer.new(ssl: true) }
 
     let(:extra_options) { {} }
 
     let(:client) do
-      described_class.new options.merge(:ssl_context => SSLHelper.client_context).merge(extra_options)
+      described_class.new options.merge(ssl_context: SSLHelper.client_context).merge(extra_options)
     end
 
     include_context "HTTP handling" do
@@ -230,7 +230,7 @@ RSpec.describe HTTP::Client do
 
     context "with SSL options instead of a context" do
       let(:client) do
-        described_class.new options.merge :ssl => SSLHelper.client_params
+        described_class.new options.merge ssl: SSLHelper.client_params
       end
 
       it "just works" do

--- a/spec/lib/http/headers_spec.rb
+++ b/spec/lib/http/headers_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe HTTP::Headers do
     before do
       headers.set :host, "example.com"
       headers.set :accept, "application/json"
-      headers.merge! :accept => "plain/text", :cookie => %w(hoo=ray woo=hoo)
+      headers.merge! accept: "plain/text", cookie: %w(hoo=ray woo=hoo)
     end
 
     it "leaves headers not presented in other as is" do
@@ -404,7 +404,7 @@ RSpec.describe HTTP::Headers do
     end
 
     subject(:merged) do
-      headers.merge :accept => "plain/text", :cookie => %w(hoo=ray woo=hoo)
+      headers.merge accept: "plain/text", cookie: %w(hoo=ray woo=hoo)
     end
 
     it { is_expected.to be_a described_class }
@@ -431,17 +431,17 @@ RSpec.describe HTTP::Headers do
     let(:dummyClass) { Class.new { def respond_to?(*); end } }
 
     it "accepts any object that respond to #to_hash" do
-      hashie = double :to_hash => {"accept" => "json"}
+      hashie = double to_hash: {"accept" => "json"}
       expect(described_class.coerce(hashie)["accept"]).to eq "json"
     end
 
     it "accepts any object that respond to #to_h" do
-      hashie = double :to_h => {"accept" => "json"}
+      hashie = double to_h: {"accept" => "json"}
       expect(described_class.coerce(hashie)["accept"]).to eq "json"
     end
 
     it "accepts any object that respond to #to_a" do
-      hashie = double :to_a => [%w(accept json)]
+      hashie = double to_a: [%w(accept json)]
       expect(described_class.coerce(hashie)["accept"]).to eq "json"
     end
 

--- a/spec/lib/http/options/form_spec.rb
+++ b/spec/lib/http/options/form_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe HTTP::Options, "form" do
   end
 
   it "may be specified with with_form_data" do
-    opts2 = opts.with_form(:foo => 42)
+    opts2 = opts.with_form(foo: 42)
     expect(opts.form).to be nil
-    expect(opts2.form).to eq(:foo => 42)
+    expect(opts2.form).to eq(foo: 42)
   end
 end

--- a/spec/lib/http/options/json_spec.rb
+++ b/spec/lib/http/options/json_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe HTTP::Options, "json" do
   end
 
   it "may be specified with with_json data" do
-    opts2 = opts.with_json(:foo => 42)
+    opts2 = opts.with_json(foo: 42)
     expect(opts.json).to be nil
-    expect(opts2.json).to eq(:foo => 42)
+    expect(opts2.json).to eq(foo: 42)
   end
 end

--- a/spec/lib/http/options/merge_spec.rb
+++ b/spec/lib/http/options/merge_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe HTTP::Options, "merge" do
 
   it "supports a Hash" do
     old_response = opts.response
-    expect(opts.merge(:response => :body).response).to eq(:body)
+    expect(opts.merge(response: :body).response).to eq(:body)
     expect(opts.response).to eq(old_response)
   end
 
   it "supports another Options" do
-    merged = opts.merge(HTTP::Options.new(:response => :body))
+    merged = opts.merge(HTTP::Options.new(response: :body))
     expect(merged.response).to eq(:body)
   end
 
@@ -17,46 +17,46 @@ RSpec.describe HTTP::Options, "merge" do
     # FIXME: yuck :(
 
     foo = HTTP::Options.new(
-      :response  => :body,
-      :params    => {:baz => "bar"},
-      :form      => {:foo => "foo"},
-      :body      => "body-foo",
-      :json      => {:foo => "foo"},
-      :headers   => {:accept => "json", :foo => "foo"},
-      :proxy     => {})
+      response:  :body,
+      params:    {baz: "bar"},
+      form:      {foo: "foo"},
+      body:      "body-foo",
+      json:      {foo: "foo"},
+      headers:   {accept: "json", foo: "foo"},
+      proxy:     {})
 
     bar = HTTP::Options.new(
-      :response   => :parsed_body,
-      :persistent => "https://www.googe.com",
-      :params     => {:plop => "plip"},
-      :form       => {:bar => "bar"},
-      :body       => "body-bar",
-      :json       => {:bar => "bar"},
-      :keep_alive_timeout => 10,
-      :headers            => {:accept => "xml", :bar => "bar"},
-      :timeout_options    => {:foo => :bar},
-      :ssl        => {:foo => "bar"},
-      :proxy      => {:proxy_address => "127.0.0.1", :proxy_port => 8080})
+      response:   :parsed_body,
+      persistent: "https://www.googe.com",
+      params:     {plop: "plip"},
+      form:       {bar: "bar"},
+      body:       "body-bar",
+      json:       {bar: "bar"},
+      keep_alive_timeout: 10,
+      headers:            {accept: "xml", bar: "bar"},
+      timeout_options:    {foo: :bar},
+      ssl:        {foo: "bar"},
+      proxy:      {proxy_address: "127.0.0.1", proxy_port: 8080})
 
     expect(foo.merge(bar).to_hash).to eq(
-      :response        => :parsed_body,
-      :timeout_class   => described_class.default_timeout_class,
-      :timeout_options => {:foo => :bar},
-      :params     => {:plop => "plip"},
-      :form       => {:bar => "bar"},
-      :body       => "body-bar",
-      :json       => {:bar => "bar"},
-      :persistent => "https://www.googe.com",
-      :keep_alive_timeout => 10,
-      :ssl       => {:foo => "bar"},
-      :headers   => {"Foo" => "foo", "Accept" => "xml", "Bar" => "bar"},
-      :proxy     => {:proxy_address => "127.0.0.1", :proxy_port => 8080},
-      :follow => nil,
-      :socket_class     => described_class.default_socket_class,
-      :nodelay          => false,
-      :ssl_socket_class => described_class.default_ssl_socket_class,
-      :ssl_context      => nil,
-      :cookies          => {},
-      :encoding         => nil)
+      response:        :parsed_body,
+      timeout_class:   described_class.default_timeout_class,
+      timeout_options: {foo: :bar},
+      params:     {plop: "plip"},
+      form:       {bar: "bar"},
+      body:       "body-bar",
+      json:       {bar: "bar"},
+      persistent: "https://www.googe.com",
+      keep_alive_timeout: 10,
+      ssl:       {foo: "bar"},
+      headers:   {"Foo" => "foo", "Accept" => "xml", "Bar" => "bar"},
+      proxy:     {proxy_address: "127.0.0.1", proxy_port: 8080},
+      follow: nil,
+      socket_class:     described_class.default_socket_class,
+      nodelay:          false,
+      ssl_socket_class: described_class.default_ssl_socket_class,
+      ssl_context:      nil,
+      cookies:          {},
+      encoding:         nil)
   end
 end

--- a/spec/lib/http/options/new_spec.rb
+++ b/spec/lib/http/options/new_spec.rb
@@ -6,23 +6,23 @@ RSpec.describe HTTP::Options, "new" do
 
   context "with a Hash" do
     it "coerces :response correctly" do
-      opts = HTTP::Options.new(:response => :object)
+      opts = HTTP::Options.new(response: :object)
       expect(opts.response).to eq(:object)
     end
 
     it "coerces :headers correctly" do
-      opts = HTTP::Options.new(:headers => {:accept => "json"})
+      opts = HTTP::Options.new(headers: {accept: "json"})
       expect(opts.headers).to eq([%w(Accept json)])
     end
 
     it "coerces :proxy correctly" do
-      opts = HTTP::Options.new(:proxy => {:proxy_address => "127.0.0.1", :proxy_port => 8080})
-      expect(opts.proxy).to eq(:proxy_address => "127.0.0.1", :proxy_port => 8080)
+      opts = HTTP::Options.new(proxy: {proxy_address: "127.0.0.1", proxy_port: 8080})
+      expect(opts.proxy).to eq(proxy_address: "127.0.0.1", proxy_port: 8080)
     end
 
     it "coerces :form correctly" do
-      opts = HTTP::Options.new(:form => {:foo => 42})
-      expect(opts.form).to eq(:foo => 42)
+      opts = HTTP::Options.new(form: {foo: 42})
+      expect(opts.form).to eq(foo: 42)
     end
   end
 end

--- a/spec/lib/http/options/proxy_spec.rb
+++ b/spec/lib/http/options/proxy_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe HTTP::Options, "proxy" do
   end
 
   it "may be specified with with_proxy" do
-    opts2 = opts.with_proxy(:proxy_address => "127.0.0.1", :proxy_port => 8080)
+    opts2 = opts.with_proxy(proxy_address: "127.0.0.1", proxy_port: 8080)
     expect(opts.proxy).to eq({})
-    expect(opts2.proxy).to eq(:proxy_address => "127.0.0.1", :proxy_port => 8080)
+    expect(opts2.proxy).to eq(proxy_address: "127.0.0.1", proxy_port: 8080)
   end
 
   it "accepts proxy address, port, username, and password" do
-    opts2 = opts.with_proxy(:proxy_address => "127.0.0.1", :proxy_port => 8080, :proxy_username => "username", :proxy_password => "password")
-    expect(opts2.proxy).to eq(:proxy_address => "127.0.0.1", :proxy_port => 8080, :proxy_username => "username", :proxy_password => "password")
+    opts2 = opts.with_proxy(proxy_address: "127.0.0.1", proxy_port: 8080, proxy_username: "username", proxy_password: "password")
+    expect(opts2.proxy).to eq(proxy_address: "127.0.0.1", proxy_port: 8080, proxy_username: "username", proxy_password: "password")
   end
 end

--- a/spec/lib/http/options_spec.rb
+++ b/spec/lib/http/options_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe HTTP::Options do
-  subject { described_class.new(:response => :body) }
+  subject { described_class.new(response: :body) }
 
   it "has reader methods for attributes" do
     expect(subject.response).to eq(:body)

--- a/spec/lib/http/redirector_spec.rb
+++ b/spec/lib/http/redirector_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe HTTP::Redirector do
   def simple_response(status, body = "", headers = {})
     HTTP::Response.new(
-      :status  => status,
-      :version => "1.1",
-      :headers => headers,
-      :body    => body
+      status:  status,
+      version: "1.1",
+      headers: headers,
+      body:    body
     )
   end
 
@@ -35,7 +35,7 @@ RSpec.describe HTTP::Redirector do
     let(:redirector) { described_class.new options }
 
     it "fails with TooManyRedirectsError if max hops reached" do
-      req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+      req = HTTP::Request.new verb: :head, uri: "http://example.com"
       res = proc { |prev_req| redirect_response(301, "#{prev_req.uri}/1") }
 
       expect { redirector.perform(req, res.call(req), &res) }.
@@ -43,7 +43,7 @@ RSpec.describe HTTP::Redirector do
     end
 
     it "fails with EndlessRedirectError if endless loop detected" do
-      req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+      req = HTTP::Request.new verb: :head, uri: "http://example.com"
       res = redirect_response(301, req.uri)
 
       expect { redirector.perform(req, res) { res } }.
@@ -51,7 +51,7 @@ RSpec.describe HTTP::Redirector do
     end
 
     it "fails with StateError if there were no Location header" do
-      req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+      req = HTTP::Request.new verb: :head, uri: "http://example.com"
       res = simple_response(301)
 
       expect { |b| redirector.perform(req, res, &b) }.
@@ -59,7 +59,7 @@ RSpec.describe HTTP::Redirector do
     end
 
     it "returns first non-redirect response" do
-      req  = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+      req  = HTTP::Request.new verb: :head, uri: "http://example.com"
       hops = [
         redirect_response(301, "http://example.com/1"),
         redirect_response(301, "http://example.com/2"),
@@ -75,10 +75,10 @@ RSpec.describe HTTP::Redirector do
 
     context "following 300 redirect" do
       context "with strict mode" do
-        let(:options) { {:strict => true} }
+        let(:options) { {strict: true} }
 
         it "it follows with original verb if it's safe" do
-          req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :head, uri: "http://example.com"
           res = redirect_response 300, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -88,7 +88,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "raises StateError if original request was PUT" do
-          req = HTTP::Request.new :verb => :put, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :put, uri: "http://example.com"
           res = redirect_response 300, "http://example.com/1"
 
           expect { redirector.perform(req, res) { simple_response 200 } }.
@@ -96,7 +96,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "raises StateError if original request was POST" do
-          req = HTTP::Request.new :verb => :post, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :post, uri: "http://example.com"
           res = redirect_response 300, "http://example.com/1"
 
           expect { redirector.perform(req, res) { simple_response 200 } }.
@@ -104,7 +104,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "raises StateError if original request was DELETE" do
-          req = HTTP::Request.new :verb => :delete, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :delete, uri: "http://example.com"
           res = redirect_response 300, "http://example.com/1"
 
           expect { redirector.perform(req, res) { simple_response 200 } }.
@@ -113,10 +113,10 @@ RSpec.describe HTTP::Redirector do
       end
 
       context "with non-strict mode" do
-        let(:options) { {:strict => false} }
+        let(:options) { {strict: false} }
 
         it "it follows with original verb if it's safe" do
-          req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :head, uri: "http://example.com"
           res = redirect_response 300, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -126,7 +126,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "it follows with GET if original request was PUT" do
-          req = HTTP::Request.new :verb => :put, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :put, uri: "http://example.com"
           res = redirect_response 300, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -136,7 +136,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "it follows with GET if original request was POST" do
-          req = HTTP::Request.new :verb => :post, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :post, uri: "http://example.com"
           res = redirect_response 300, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -146,7 +146,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "it follows with GET if original request was DELETE" do
-          req = HTTP::Request.new :verb => :delete, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :delete, uri: "http://example.com"
           res = redirect_response 300, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -159,10 +159,10 @@ RSpec.describe HTTP::Redirector do
 
     context "following 301 redirect" do
       context "with strict mode" do
-        let(:options) { {:strict => true} }
+        let(:options) { {strict: true} }
 
         it "it follows with original verb if it's safe" do
-          req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :head, uri: "http://example.com"
           res = redirect_response 301, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -172,7 +172,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "raises StateError if original request was PUT" do
-          req = HTTP::Request.new :verb => :put, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :put, uri: "http://example.com"
           res = redirect_response 301, "http://example.com/1"
 
           expect { redirector.perform(req, res) { simple_response 200 } }.
@@ -180,7 +180,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "raises StateError if original request was POST" do
-          req = HTTP::Request.new :verb => :post, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :post, uri: "http://example.com"
           res = redirect_response 301, "http://example.com/1"
 
           expect { redirector.perform(req, res) { simple_response 200 } }.
@@ -188,7 +188,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "raises StateError if original request was DELETE" do
-          req = HTTP::Request.new :verb => :delete, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :delete, uri: "http://example.com"
           res = redirect_response 301, "http://example.com/1"
 
           expect { redirector.perform(req, res) { simple_response 200 } }.
@@ -197,10 +197,10 @@ RSpec.describe HTTP::Redirector do
       end
 
       context "with non-strict mode" do
-        let(:options) { {:strict => false} }
+        let(:options) { {strict: false} }
 
         it "it follows with original verb if it's safe" do
-          req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :head, uri: "http://example.com"
           res = redirect_response 301, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -210,7 +210,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "it follows with GET if original request was PUT" do
-          req = HTTP::Request.new :verb => :put, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :put, uri: "http://example.com"
           res = redirect_response 301, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -220,7 +220,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "it follows with GET if original request was POST" do
-          req = HTTP::Request.new :verb => :post, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :post, uri: "http://example.com"
           res = redirect_response 301, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -230,7 +230,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "it follows with GET if original request was DELETE" do
-          req = HTTP::Request.new :verb => :delete, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :delete, uri: "http://example.com"
           res = redirect_response 301, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -243,10 +243,10 @@ RSpec.describe HTTP::Redirector do
 
     context "following 302 redirect" do
       context "with strict mode" do
-        let(:options) { {:strict => true} }
+        let(:options) { {strict: true} }
 
         it "it follows with original verb if it's safe" do
-          req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :head, uri: "http://example.com"
           res = redirect_response 302, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -256,7 +256,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "raises StateError if original request was PUT" do
-          req = HTTP::Request.new :verb => :put, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :put, uri: "http://example.com"
           res = redirect_response 302, "http://example.com/1"
 
           expect { redirector.perform(req, res) { simple_response 200 } }.
@@ -264,7 +264,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "raises StateError if original request was POST" do
-          req = HTTP::Request.new :verb => :post, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :post, uri: "http://example.com"
           res = redirect_response 302, "http://example.com/1"
 
           expect { redirector.perform(req, res) { simple_response 200 } }.
@@ -272,7 +272,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "raises StateError if original request was DELETE" do
-          req = HTTP::Request.new :verb => :delete, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :delete, uri: "http://example.com"
           res = redirect_response 302, "http://example.com/1"
 
           expect { redirector.perform(req, res) { simple_response 200 } }.
@@ -281,10 +281,10 @@ RSpec.describe HTTP::Redirector do
       end
 
       context "with non-strict mode" do
-        let(:options) { {:strict => false} }
+        let(:options) { {strict: false} }
 
         it "it follows with original verb if it's safe" do
-          req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :head, uri: "http://example.com"
           res = redirect_response 302, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -294,7 +294,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "it follows with GET if original request was PUT" do
-          req = HTTP::Request.new :verb => :put, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :put, uri: "http://example.com"
           res = redirect_response 302, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -304,7 +304,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "it follows with GET if original request was POST" do
-          req = HTTP::Request.new :verb => :post, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :post, uri: "http://example.com"
           res = redirect_response 302, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -314,7 +314,7 @@ RSpec.describe HTTP::Redirector do
         end
 
         it "it follows with GET if original request was DELETE" do
-          req = HTTP::Request.new :verb => :delete, :uri => "http://example.com"
+          req = HTTP::Request.new verb: :delete, uri: "http://example.com"
           res = redirect_response 302, "http://example.com/1"
 
           redirector.perform(req, res) do |prev_req, _|
@@ -327,7 +327,7 @@ RSpec.describe HTTP::Redirector do
 
     context "following 303 redirect" do
       it "follows with HEAD if original request was HEAD" do
-        req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+        req = HTTP::Request.new verb: :head, uri: "http://example.com"
         res = redirect_response 303, "http://example.com/1"
 
         redirector.perform(req, res) do |prev_req, _|
@@ -337,7 +337,7 @@ RSpec.describe HTTP::Redirector do
       end
 
       it "follows with GET if original request was GET" do
-        req = HTTP::Request.new :verb => :get, :uri => "http://example.com"
+        req = HTTP::Request.new verb: :get, uri: "http://example.com"
         res = redirect_response 303, "http://example.com/1"
 
         redirector.perform(req, res) do |prev_req, _|
@@ -347,7 +347,7 @@ RSpec.describe HTTP::Redirector do
       end
 
       it "follows with GET if original request was neither GET nor HEAD" do
-        req = HTTP::Request.new :verb => :post, :uri => "http://example.com"
+        req = HTTP::Request.new verb: :post, uri: "http://example.com"
         res = redirect_response 303, "http://example.com/1"
 
         redirector.perform(req, res) do |prev_req, _|
@@ -359,7 +359,7 @@ RSpec.describe HTTP::Redirector do
 
     context "following 307 redirect" do
       it "follows with original request's verb" do
-        req = HTTP::Request.new :verb => :post, :uri => "http://example.com"
+        req = HTTP::Request.new verb: :post, uri: "http://example.com"
         res = redirect_response 307, "http://example.com/1"
 
         redirector.perform(req, res) do |prev_req, _|
@@ -371,7 +371,7 @@ RSpec.describe HTTP::Redirector do
 
     context "following 308 redirect" do
       it "follows with original request's verb" do
-        req = HTTP::Request.new :verb => :post, :uri => "http://example.com"
+        req = HTTP::Request.new verb: :post, uri: "http://example.com"
         res = redirect_response 308, "http://example.com/1"
 
         redirector.perform(req, res) do |prev_req, _|

--- a/spec/lib/http/request_spec.rb
+++ b/spec/lib/http/request_spec.rb
@@ -2,15 +2,15 @@
 
 RSpec.describe HTTP::Request do
   let(:proxy)       { {} }
-  let(:headers)     { {:accept => "text/html"} }
+  let(:headers)     { {accept: "text/html"} }
   let(:request_uri) { "http://example.com/foo?bar=baz" }
 
   subject :request do
     HTTP::Request.new(
-      :verb     => :get,
-      :uri      => request_uri,
-      :headers  => headers,
-      :proxy    => proxy
+      verb:     :get,
+      uri:      request_uri,
+      headers:  headers,
+      proxy:    proxy
     )
   end
 
@@ -19,7 +19,7 @@ RSpec.describe HTTP::Request do
   end
 
   it "requires URI to have scheme part" do
-    expect { HTTP::Request.new(:verb => :get, :uri => "example.com/") }.to \
+    expect { HTTP::Request.new(verb: :get, uri: "example.com/") }.to \
       raise_error(HTTP::Request::UnsupportedSchemeError)
   end
 
@@ -67,17 +67,17 @@ RSpec.describe HTTP::Request do
   end
 
   describe "#redirect" do
-    let(:headers)   { {:accept => "text/html"} }
-    let(:proxy)     { {:proxy_username => "douglas", :proxy_password => "adams"} }
+    let(:headers)   { {accept: "text/html"} }
+    let(:proxy)     { {proxy_username: "douglas", proxy_password: "adams"} }
     let(:body)      { "The Ultimate Question" }
 
     let :request do
       HTTP::Request.new(
-        :verb    => :post,
-        :uri     => "http://example.com/",
-        :headers => headers,
-        :proxy   => proxy,
-        :body    => body
+        verb:    :post,
+        uri:     "http://example.com/",
+        headers: headers,
+        proxy:   proxy,
+        body:    body
       )
     end
 
@@ -123,11 +123,11 @@ RSpec.describe HTTP::Request do
       context "with original URI having non-standard port" do
         let :request do
           HTTP::Request.new(
-            :verb    => :post,
-            :uri     => "http://example.com:8080/",
-            :headers => headers,
-            :proxy   => proxy,
-            :body    => body
+            verb:    :post,
+            uri:     "http://example.com:8080/",
+            headers: headers,
+            proxy:   proxy,
+            body:    body
           )
         end
 
@@ -151,11 +151,11 @@ RSpec.describe HTTP::Request do
       context "with original URI having non-standard port" do
         let :request do
           HTTP::Request.new(
-            :verb    => :post,
-            :uri     => "http://example.com:8080/",
-            :headers => headers,
-            :proxy   => proxy,
-            :body    => body
+            verb:    :post,
+            uri:     "http://example.com:8080/",
+            headers: headers,
+            proxy:   proxy,
+            body:    body
           )
         end
 
@@ -200,7 +200,7 @@ RSpec.describe HTTP::Request do
     end
 
     context "with proxy" do
-      let(:proxy) { {:user => "user", :pass => "pass"} }
+      let(:proxy) { {user: "user", pass: "pass"} }
       it { is_expected.to eq "GET http://example.com/foo?bar=baz HTTP/1.1" }
 
       context "and HTTPS uri" do

--- a/spec/lib/http/response/body_spec.rb
+++ b/spec/lib/http/response/body_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe HTTP::Response::Body do
-  let(:client)   { double(:sequence_id => 0) }
+  let(:client)   { double(sequence_id: 0) }
   let(:chunks)   { ["Hello, ", "World!"] }
 
   before         { allow(client).to receive(:readpartial) { chunks.shift } }

--- a/spec/lib/http/response/status_spec.rb
+++ b/spec/lib/http/response/status_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe HTTP::Response::Status do
     end
 
     it "accepts any object that responds to #to_i" do
-      expect { described_class.new double :to_i => 200 }.to_not raise_error
+      expect { described_class.new double to_i: 200 }.to_not raise_error
     end
   end
 

--- a/spec/lib/http/response_spec.rb
+++ b/spec/lib/http/response_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe HTTP::Response do
 
   subject(:response) do
     HTTP::Response.new(
-      :status  => 200,
-      :version => "1.1",
-      :headers => headers,
-      :body    => body,
-      :uri     => uri
+      status:  200,
+      version: "1.1",
+      headers: headers,
+      body:    body,
+      uri:     uri
     )
   end
 
@@ -96,7 +96,7 @@ RSpec.describe HTTP::Response do
   end
 
   describe "#flush" do
-    let(:body) { double :to_s => "" }
+    let(:body) { double to_s: "" }
 
     it "returns response self-reference" do
       expect(response.flush).to be response
@@ -109,8 +109,8 @@ RSpec.describe HTTP::Response do
   end
 
   describe "#inspect" do
-    let(:headers) { {:content_type => "text/plain"} }
-    let(:body)    { double :to_s => "foobar" }
+    let(:headers) { {content_type: "text/plain"} }
+    let(:body)    { double to_s: "foobar" }
 
     it "returns human-friendly response representation" do
       expect(response.inspect).

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -7,10 +7,10 @@ require "support/proxy_server"
 
 RSpec.describe HTTP do
   run_server(:dummy) { DummyServer.new }
-  run_server(:dummy_ssl) { DummyServer.new(:ssl => true) }
+  run_server(:dummy_ssl) { DummyServer.new(ssl: true) }
 
   let(:ssl_client) do
-    HTTP::Client.new :ssl_context => SSLHelper.client_context
+    HTTP::Client.new ssl_context: SSLHelper.client_context
   end
 
   context "getting resources" do
@@ -28,14 +28,14 @@ RSpec.describe HTTP do
 
     context "with query string parameters" do
       it "is easy" do
-        response = HTTP.get "#{dummy.endpoint}/params", :params => {:foo => "bar"}
+        response = HTTP.get "#{dummy.endpoint}/params", params: {foo: "bar"}
         expect(response.to_s).to match(/Params!/)
       end
     end
 
     context "with query string parameters in the URI and opts hash" do
       it "includes both" do
-        response = HTTP.get "#{dummy.endpoint}/multiple-params?foo=bar", :params => {:baz => "quux"}
+        response = HTTP.get "#{dummy.endpoint}/multiple-params?foo=bar", params: {baz: "quux"}
         expect(response.to_s).to match(/More Params!/)
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe HTTP do
           [16_000, 16_500, 17_000, 34_000, 68_000].each do |size|
             [0, rand(0..100), rand(100..1000)].each do |fuzzer|
               context "with a #{size} body and #{fuzzer} of fuzzing" do
-                let(:client) { HTTP.timeout(timeout, :read => 2, :write => 2, :connect => 2) }
+                let(:client) { HTTP.timeout(timeout, read: 2, write: 2, connect: 2) }
 
                 let(:characters) { ("A".."Z").to_a }
                 let(:request_body) do
@@ -61,7 +61,7 @@ RSpec.describe HTTP do
                 end
 
                 it "returns a large body" do
-                  response = client.post("#{dummy.endpoint}/echo-body", :body => request_body)
+                  response = client.post("#{dummy.endpoint}/echo-body", body: request_body)
 
                   expect(response.body.to_s).to eq(request_body)
                   expect(response.headers["Content-Length"].to_i).to eq(request_body.bytesize)
@@ -71,8 +71,8 @@ RSpec.describe HTTP do
                   let(:characters) { ("A".."Z").to_a.push("“") }
 
                   it "returns a large body" do
-                    body = {:data => request_body}
-                    response = client.post("#{dummy.endpoint}/echo-body", :json => body)
+                    body = {data: request_body}
+                    response = client.post("#{dummy.endpoint}/echo-body", json: body)
 
                     expect(CGI.unescape(response.body.to_s)).to eq(body.to_json)
                     expect(response.headers["Content-Length"].to_i).to eq(body.to_json.bytesize)
@@ -166,7 +166,7 @@ RSpec.describe HTTP do
 
   context "posting forms to resources" do
     it "is easy" do
-      response = HTTP.post "#{dummy.endpoint}/form", :form => {:example => "testing-form"}
+      response = HTTP.post "#{dummy.endpoint}/form", form: {example: "testing-form"}
       expect(response.to_s).to eq("passed :)")
     end
   end
@@ -209,7 +209,7 @@ RSpec.describe HTTP do
 
   context "posting with an explicit body" do
     it "is easy" do
-      response = HTTP.post "#{dummy.endpoint}/body", :body => "testing-body"
+      response = HTTP.post "#{dummy.endpoint}/body", body: "testing-body"
       expect(response.to_s).to eq("passed :)")
     end
   end
@@ -241,7 +241,7 @@ RSpec.describe HTTP do
     end
 
     it "accepts any #to_s object" do
-      client = HTTP.auth double :to_s => "abc"
+      client = HTTP.auth double to_s: "abc"
       expect(client.default_options.headers[:authorization]).to eq "abc"
     end
   end
@@ -252,15 +252,15 @@ RSpec.describe HTTP do
     end
 
     it "fails when :pass is not given" do
-      expect { HTTP.basic_auth :user => "[USER]" }.to raise_error
+      expect { HTTP.basic_auth user: "[USER]" }.to raise_error
     end
 
     it "fails when :user is not given" do
-      expect { HTTP.basic_auth :pass => "[PASS]" }.to raise_error
+      expect { HTTP.basic_auth pass: "[PASS]" }.to raise_error
     end
 
     it "sets Authorization header with proper BasicAuth value" do
-      client = HTTP.basic_auth :user => "foo", :pass => "bar"
+      client = HTTP.basic_auth user: "foo", pass: "bar"
       expect(client.default_options.headers[:authorization]).
         to match(%r{^Basic [A-Za-z0-9+/]+=*$})
     end
@@ -291,7 +291,7 @@ RSpec.describe HTTP do
 
   describe ".timeout" do
     context "without timeout type" do
-      subject(:client) { HTTP.timeout :read => 123 }
+      subject(:client) { HTTP.timeout read: 123 }
 
       it "sets timeout_class to PerOperation" do
         expect(client.default_options.timeout_class).
@@ -300,12 +300,12 @@ RSpec.describe HTTP do
 
       it "sets given timeout options" do
         expect(client.default_options.timeout_options).
-          to eq :read_timeout => 123
+          to eq read_timeout: 123
       end
     end
 
     context "with :null type" do
-      subject(:client) { HTTP.timeout :null, :read => 123 }
+      subject(:client) { HTTP.timeout :null, read: 123 }
 
       it "sets timeout_class to Null" do
         expect(client.default_options.timeout_class).
@@ -314,7 +314,7 @@ RSpec.describe HTTP do
     end
 
     context "with :per_operation type" do
-      subject(:client) { HTTP.timeout :per_operation, :read => 123 }
+      subject(:client) { HTTP.timeout :per_operation, read: 123 }
 
       it "sets timeout_class to PerOperation" do
         expect(client.default_options.timeout_class).
@@ -323,12 +323,12 @@ RSpec.describe HTTP do
 
       it "sets given timeout options" do
         expect(client.default_options.timeout_options).
-          to eq :read_timeout => 123
+          to eq read_timeout: 123
       end
     end
 
     context "with :global type" do
-      subject(:client) { HTTP.timeout :global, :read => 123 }
+      subject(:client) { HTTP.timeout :global, read: 123 }
 
       it "sets timeout_class to Global" do
         expect(client.default_options.timeout_class).
@@ -337,12 +337,12 @@ RSpec.describe HTTP do
 
       it "sets given timeout options" do
         expect(client.default_options.timeout_options).
-          to eq :read_timeout => 123
+          to eq read_timeout: 123
       end
     end
 
     it "fails with unknown timeout type" do
-      expect { HTTP.timeout(:foobar, :read => 123) }.
+      expect { HTTP.timeout(:foobar, read: 123) }.
         to raise_error(ArgumentError, /foobar/)
     end
   end
@@ -351,7 +351,7 @@ RSpec.describe HTTP do
     let(:endpoint) { "#{dummy.endpoint}/cookies" }
 
     it "passes correct `Cookie` header" do
-      expect(HTTP.cookies(:abc => :def).get(endpoint).to_s).
+      expect(HTTP.cookies(abc: :def).get(endpoint).to_s).
         to eq "abc: def"
     end
 
@@ -364,13 +364,13 @@ RSpec.describe HTTP do
 
     it "properly merges cookies" do
       res     = HTTP.get(endpoint).flush
-      client  = HTTP.cookies(:foo => 123, :bar => 321).cookies(res.cookies)
+      client  = HTTP.cookies(foo: 123, bar: 321).cookies(res.cookies)
 
       expect(client.get(endpoint).to_s).to eq "foo: bar\nbar: 321"
     end
 
     it "properly merges Cookie headers and cookies" do
-      client = HTTP.headers("Cookie" => "foo=bar").cookies(:baz => :moo)
+      client = HTTP.headers("Cookie" => "foo=bar").cookies(baz: :moo)
       expect(client.get(endpoint).to_s).to eq "foo: bar\nbaz: moo"
     end
 
@@ -382,7 +382,7 @@ RSpec.describe HTTP do
 
   describe ".nodelay" do
     before do
-      HTTP.default_options = {:socket_class => socket_spy_class}
+      HTTP.default_options = {socket_class: socket_spy_class}
     end
 
     after do

--- a/spec/support/dummy_server.rb
+++ b/spec/support/dummy_server.rb
@@ -11,15 +11,15 @@ class DummyServer < WEBrick::HTTPServer
   include ServerConfig
 
   CONFIG = {
-    :BindAddress  => "127.0.0.1",
-    :Port         => 0,
-    :AccessLog    => BlackHole,
-    :Logger       => BlackHole
+    BindAddress:  "127.0.0.1",
+    Port:         0,
+    AccessLog:    BlackHole,
+    Logger:       BlackHole
   }.freeze
 
   SSL_CONFIG = CONFIG.merge(
-    :SSLEnable            => true,
-    :SSLStartImmediately  => true
+    SSLEnable:            true,
+    SSLStartImmediately:  true
   ).freeze
 
   def initialize(options = {})

--- a/spec/support/http_handling_shared.rb
+++ b/spec/support/http_handling_shared.rb
@@ -6,11 +6,11 @@ RSpec.shared_context "HTTP handling" do
 
     let(:options) do
       {
-        :timeout_class => timeout_class,
-        :timeout_options => {
-          :connect_timeout => conn_timeout,
-          :read_timeout => read_timeout,
-          :write_timeout => write_timeout
+        timeout_class: timeout_class,
+        timeout_options: {
+          connect_timeout: conn_timeout,
+          read_timeout: read_timeout,
+          write_timeout: write_timeout
         }
       }
     end
@@ -91,7 +91,7 @@ RSpec.shared_context "HTTP handling" do
       end
 
       context "it resets state when reusing connections" do
-        let(:extra_options) { {:persistent => server.endpoint} }
+        let(:extra_options) { {persistent: server.endpoint} }
 
         let(:read_timeout) { 2.5 }
 
@@ -115,7 +115,7 @@ RSpec.shared_context "HTTP handling" do
     end
 
     context "when enabled" do
-      let(:options) { {:persistent => server.endpoint} }
+      let(:options) { {persistent: server.endpoint} }
 
       context "without a host" do
         it "infers host from persistent config" do

--- a/spec/support/proxy_server.rb
+++ b/spec/support/proxy_server.rb
@@ -8,11 +8,11 @@ class ProxyServer < WEBrick::HTTPProxyServer
   include ServerConfig
 
   CONFIG = {
-    :BindAddress     => "127.0.0.1",
-    :Port            => 0,
-    :AccessLog       => BlackHole,
-    :Logger          => BlackHole,
-    :RequestCallback => proc { |_, res| res["X-PROXIED"] = true }
+    BindAddress:     "127.0.0.1",
+    Port:            0,
+    AccessLog:       BlackHole,
+    Logger:          BlackHole,
+    RequestCallback: proc { |_, res| res["X-PROXIED"] = true }
   }.freeze
 
   def initialize
@@ -29,7 +29,7 @@ class AuthProxyServer < WEBrick::HTTPProxyServer
     end
   end
 
-  CONFIG = ProxyServer::CONFIG.merge :ProxyAuthProc => AUTHENTICATOR
+  CONFIG = ProxyServer::CONFIG.merge ProxyAuthProc: AUTHENTICATOR
 
   def initialize
     super CONFIG

--- a/spec/support/ssl_helper.rb
+++ b/spec/support/ssl_helper.rb
@@ -81,9 +81,9 @@ module SSLHelper
 
     def client_params
       {
-        :key => client_cert.key,
-        :cert => client_cert.cert,
-        :ca_file => ca.file
+        key: client_cert.key,
+        cert: client_cert.cert,
+        ca_file: ca.file
       }
     end
 


### PR DESCRIPTION
Since support for 1.8.7 is long gone, and since all supported versions of Ruby support keyword args, it seems like a good time to prefer the use of the 1.9 alternate hash literal syntax, enforced by default by Rubocop. 