### PR TITLE
faster string manipulation in response status

### DIFF
--- a/lib/http/response/status.rb
+++ b/lib/http/response/status.rb
@@ -43,7 +43,7 @@ module HTTP
         # @param [#to_s] str
         # @return [Symbol]
         def symbolize(str)
-          str.to_s.downcase.tr("-", " ").gsub(/[^a-z ]/, "").gsub(/\s+/, "_").to_sym
+          str.to_s.downcase.tr("- ", "_").delete("^a-z_").to_sym
         end
       end
 


### PR DESCRIPTION
Introduces backward-incompatible change:

```
[1] pry(main)> HTTP::Response::Status.coerce "Bad    Request"
HTTP::Error: Can't coerce String(Bad    Request) to HTTP::Response::Status
from /home/ixti/Projects/httprb/http/lib/http/response/status.rb:29:in `coerce'
```

Behavior before this patch:

```
[1] pry(main)> HTTP::Response::Status.coerce "Bad    Request"
=> 400
```
