### PR TITLE
Set required Ruby version to 2.0 in gemspec

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = HTTP::VERSION
 
+  gem.required_ruby_version = ">= 2.0"
+
   gem.add_runtime_dependency "http_parser.rb", "~> 0.6.0"
   gem.add_runtime_dependency "http-form_data", "~> 1.0.1"
   gem.add_runtime_dependency "http-cookie",    "~> 1.0"


### PR DESCRIPTION
Seems we never captured this before...