### PR TITLE
Avoid a dependency cycle between Client and Connection classes.

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -14,10 +14,7 @@ module HTTP
     extend Forwardable
     include Chainable
 
-    KEEP_ALIVE         = "Keep-Alive".freeze
-    CLOSE              = "close".freeze
-
-    HTTP_OR_HTTPS_RE   = %r{^https?://}i
+    HTTP_OR_HTTPS_RE = %r{^https?://}i
 
     def initialize(default_options = {})
       @default_options = HTTP::Options.new(default_options)
@@ -139,7 +136,7 @@ module HTTP
       headers = opts.headers
 
       # Tell the server to keep the conn open
-      headers[Headers::CONNECTION] = default_options.persistent? ? KEEP_ALIVE : CLOSE
+      headers[Headers::CONNECTION] = default_options.persistent? ? Connection::KEEP_ALIVE : Connection::CLOSE
 
       cookies = opts.cookies.values
 

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "forwardable"
 
-require "http/client"
 require "http/headers"
 require "http/response/parser"
 
@@ -9,6 +8,10 @@ module HTTP
   # A connection to the HTTP server
   class Connection
     extend Forwardable
+
+    # Allowed values for CONNECTION header
+    KEEP_ALIVE = "Keep-Alive".freeze
+    CLOSE      = "close".freeze
 
     # Attempt to read this much data
     BUFFER_SIZE = 16_384
@@ -193,9 +196,9 @@ module HTTP
       @keep_alive =
         case @parser.http_version
         when HTTP_1_0 # HTTP/1.0 requires opt in for Keep Alive
-          @parser.headers[Headers::CONNECTION] == Client::KEEP_ALIVE
+          @parser.headers[Headers::CONNECTION] == KEEP_ALIVE
         when HTTP_1_1 # HTTP/1.1 is opt-out
-          @parser.headers[Headers::CONNECTION] != Client::CLOSE
+          @parser.headers[Headers::CONNECTION] != CLOSE
         else # Anything else we assume doesn't supportit
           false
         end


### PR DESCRIPTION
I found out that sometimes you can get this error when using the gem:

    from /.../gems/http-2.0.1/lib/http.rb:8:in  `<top (required)>'
    from /.../gems/http-2.0.1/lib/http.rb:8:in  `require'
    from /.../gems/http-2.0.1/lib/http/client.rb:7:in  `<top (required)>'
    from /.../gems/http-2.0.1/lib/http/client.rb:7:in  `require'
    from /.../gems/http-2.0.1/lib/http/connection.rb:4:in  `<top (required)>'
    from /.../gems/http-2.0.1/lib/http/connection.rb:4:in  `require'

The problem was that `http.rb` was requiring `http/client.rb` that at the same time was requiring `http/connection.rb` which was requiring `http/client.rb` again.

I think that in general is not very good to have a cycle like this in the dependency graph of the code, so I decided to remove that dependency by moving the constants `KEEP_ALIVE` and `CLOSE` to the Connection class. This way Connection is now independent from Client.

Maybe this constants could go to another module but I couldn't think in a better place.