### PR TITLE
Set Content-Length request header when request body is nil

### DIFF
--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -53,6 +53,8 @@ module HTTP
       def add_body_type_headers
         if @body.is_a?(String) && !@headers[Headers::CONTENT_LENGTH]
           @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.bytesize}"
+        elsif @body.nil? && !@headers[Headers::CONTENT_LENGTH]
+          @request_header << "#{Headers::CONTENT_LENGTH}: 0"
         elsif @body.is_a?(Enumerable) && CHUNKED != @headers[Headers::TRANSFER_ENCODING]
           raise(RequestError, "invalid transfer encoding")
         end

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -69,6 +69,24 @@ RSpec.describe HTTP::Request::Writer do
       end
     end
 
+    context "when body is nil" do
+      let(:body) { nil }
+
+      it "properly sets Content-Length header if needed" do
+        writer.stream
+        expect(io.string).to start_with "#{headerstart}\r\nContent-Length: 0\r\n\r\n"
+      end
+
+      context "when Content-Length explicitly set" do
+        let(:headers) { HTTP::Headers.coerce "Content-Length" => 12 }
+
+        it "keeps given value" do
+          writer.stream
+          expect(io.string).to start_with "#{headerstart}\r\nContent-Length: 12\r\n\r\n"
+        end
+      end
+    end
+
     context "when body is a unicode String" do
       let(:body) { "Привет, мир!" }
 


### PR DESCRIPTION
This closes issue #335 by checking if the request body is `nil` and setting the `Content-Length` header to 0.

When the body is a String, the Content-Length header was already set.