### PR TITLE
Add HTTP::Response#connection

### DIFF
--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -71,6 +71,10 @@ module HTTP
     #   (see HTTP::Response::Body#readpartial)
     def_delegator :body, :readpartial
 
+    # @!method connection
+    #   (see HTTP::Response::Body#connection)
+    def_delegator :body, :connection
+
     # Returns an Array ala Rack: `[status, headers, body]`
     #
     # @return [Array(Fixnum, Hash, String)]

--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -10,17 +10,22 @@ module HTTP
       include Enumerable
       def_delegator :to_s, :empty?
 
-      def initialize(client, encoding = Encoding::BINARY)
-        @client    = client
-        @streaming = nil
-        @contents  = nil
-        @encoding  = encoding
+      # The connection object used to make the corresponding request.
+      #
+      # @return [HTTP::Connection]
+      attr_reader :connection
+
+      def initialize(connection, encoding = Encoding::BINARY)
+        @connection = connection
+        @streaming  = nil
+        @contents   = nil
+        @encoding   = encoding
       end
 
       # (see HTTP::Client#readpartial)
       def readpartial(*args)
         stream!
-        @client.readpartial(*args)
+        @connection.readpartial(*args)
       end
 
       # Iterate over the body, allowing it to be enumerable
@@ -47,7 +52,7 @@ module HTTP
           @streaming  = false
           @contents   = String.new("").force_encoding(encoding)
 
-          while (chunk = @client.readpartial)
+          while (chunk = @connection.readpartial)
             @contents << chunk.force_encoding(encoding)
           end
         rescue

--- a/spec/lib/http/response/body_spec.rb
+++ b/spec/lib/http/response/body_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 RSpec.describe HTTP::Response::Body do
-  let(:client)   { double(:sequence_id => 0) }
-  let(:chunks)   { [String.new("Hello, "), String.new("World!")] }
+  let(:connection) { double(:sequence_id => 0) }
+  let(:chunks)     { [String.new("Hello, "), String.new("World!")] }
 
-  before         { allow(client).to receive(:readpartial) { chunks.shift } }
+  before           { allow(connection).to receive(:readpartial) { chunks.shift } }
 
-  subject(:body) { described_class.new(client, Encoding::UTF_8) }
+  subject(:body)   { described_class.new(connection, Encoding::UTF_8) }
 
   it "streams bodies from responses" do
     expect(subject.to_s).to eq("Hello, World!")
@@ -21,8 +21,8 @@ RSpec.describe HTTP::Response::Body do
 
   describe "#readpartial" do
     context "with size given" do
-      it "passes value to underlying client" do
-        expect(client).to receive(:readpartial).with(42)
+      it "passes value to underlying connection" do
+        expect(connection).to receive(:readpartial).with(42)
         body.readpartial 42
       end
     end
@@ -32,8 +32,8 @@ RSpec.describe HTTP::Response::Body do
         expect { body.readpartial }.to_not raise_error
       end
 
-      it "calls underlying client readpartial without specific size" do
-        expect(client).to receive(:readpartial).with no_args
+      it "calls underlying connection readpartial without specific size" do
+        expect(connection).to receive(:readpartial).with no_args
         body.readpartial
       end
     end

--- a/spec/lib/http/response_spec.rb
+++ b/spec/lib/http/response_spec.rb
@@ -157,4 +157,20 @@ RSpec.describe HTTP::Response do
       expect(jar.count { |c| "c" == c.name }).to eq 0
     end
   end
+
+  describe "#connection" do
+    let(:connection) { double }
+
+    subject(:response) do
+      HTTP::Response.new(
+        :version    => "1.1",
+        :status     => 200,
+        :connection => connection
+      )
+    end
+
+    it "returns the connection object used to instantiate the response" do
+      expect(response.connection).to eq connection
+    end
+  end
 end


### PR DESCRIPTION
The [Down](https://github.com/janko-m/down) gem provides the ability to wrap anything that streams chunks into an IO object. I want to add support for HTTP.rb to Down so that you can do the following:

```rb
response = HTTP.any.request.options.get("http://example.com")
remote_file = Down.open(response)
remote_file # IO object which downloads only how much it needs
```

For this I need to be able to access the connection through the response object, so that I can close the connection if either the downloading finishes or user calls `remote_file.close`.