### PR TITLE
Add HTTP::Response#content_length

### DIFF
--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -86,6 +86,13 @@ module HTTP
       self
     end
 
+    # Value of the Content-Length header
+    #
+    # @return [Integer]
+    def content_length
+      Integer(headers[Headers::CONTENT_LENGTH]) if headers[Headers::CONTENT_LENGTH]
+    end
+
     # Parsed Content-Type header
     #
     # @return [HTTP::ContentType]

--- a/spec/lib/http/response_spec.rb
+++ b/spec/lib/http/response_spec.rb
@@ -28,6 +28,27 @@ RSpec.describe HTTP::Response do
     end
   end
 
+  describe "#content_length" do
+    subject { response.content_length }
+
+    context "without Content-Length header" do
+      it { is_expected.to be_nil }
+    end
+
+    context "with Content-Length: 5" do
+      let(:headers) { {"Content-Length" => "5"} }
+      it { is_expected.to eq 5 }
+    end
+
+    context "with Content-Length not an integer" do
+      let(:headers) { {"Content-Length" => "foo"} }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe "mime_type" do
     subject { response.mime_type }
 


### PR DESCRIPTION
When converting an HTTP response object to an IO, I wanted that `#size` returns the value of the Content-Length header converted to integer, or nil if it's not present:

```rb
Integer(response["Content-Length"]) if response["Content-Length"]
```

I thought it would be nice to add this convenience method to HTTP.rb.