### PR TITLE
Lock to ActiveModel 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :test do
   gem "rspec-its"
   gem "yardstick"
   gem "certificate_authority", :require => false
+  gem "activemodel", "~> 4", :require => false # Used by certificate_authority
 end
 
 group :doc do


### PR DESCRIPTION
Unfortunately certificate_authority depends on this.

This ensures we use a version that works on all Rubies we support.