### PR TITLE
Test on ActiveModel 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "rspec-its"
   gem "yardstick"
   gem "certificate_authority", :require => false
-  gem "activemodel", "~> 4", :require => false # Used by certificate_authority
+  gem "activemodel", "~> 4.0", :require => false # Used by certificate_authority
 end
 
 group :doc do


### PR DESCRIPTION
ActiveModel 5.x doesn't install on Ruby versions lower than 2.2.2.