### PR TITLE
Support for Gzip/Inflate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Metrics/LineLength:
 
 Metrics/MethodLength:
   CountComments: false
-  Max: 22 # TODO: Lower to 15
+  Max: 25 # TODO: Lower to 15
 
 Metrics/ModuleLength:
   CountComments: false

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -228,6 +228,14 @@ module HTTP
       branch default_options.with_nodelay(true)
     end
 
+    # Turn on given features. Available features are:
+    # * auto_inflate
+    # * auto_deflate
+    # @param features
+    def use(*features)
+      branch default_options.with_features(features)
+    end
+
     private
 
     # :nodoc:

--- a/lib/http/feature.rb
+++ b/lib/http/feature.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module HTTP
+  class Feature
+    def initialize(opts = {})
+      @opts = opts
+    end
+  end
+end

--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "zlib"
+
+module HTTP
+  module Features
+    class AutoDeflate < Feature
+      attr_reader :method
+
+      def initialize(*)
+        super
+
+        @method = @opts.key?(:method) ? @opts[:method].to_s : "gzip"
+
+        raise Error, "Only gzip and deflate methods are supported" unless %w(gzip deflate).include?(@method)
+      end
+
+      def deflate(headers, body)
+        return body unless body
+        return body unless body.is_a?(String)
+
+        # We need to delete Content-Length header. It will be set automatically
+        # by HTTP::Request::Writer
+        headers.delete(Headers::CONTENT_LENGTH)
+
+        headers[Headers::CONTENT_ENCODING] = method
+
+        case method
+        when "gzip" then
+          StringIO.open do |out|
+            Zlib::GzipWriter.wrap(out) do |gz|
+              gz.write body
+              gz.finish
+            end
+            out.tap(&:rewind).read
+          end
+        when "deflate" then
+          Zlib::Deflate.deflate(body)
+        else
+          raise ArgumentError, "Unsupported deflate method: #{method}"
+        end
+      end
+    end
+  end
+end

--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -31,8 +31,8 @@ module HTTP
             Zlib::GzipWriter.wrap(out) do |gz|
               gz.write body
               gz.finish
+              out.tap(&:rewind).read
             end
-            out.tap(&:rewind).read
           end
         when "deflate" then
           Zlib::Deflate.deflate(body)

--- a/lib/http/features/auto_inflate.rb
+++ b/lib/http/features/auto_inflate.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module HTTP
+  module Features
+    class AutoInflate < Feature
+      def stream_for(connection, response)
+        if %w(deflate gzip x-gzip).include?(response.headers[:content_encoding])
+          Response::Inflater.new(connection)
+        else
+          connection
+        end
+      end
+    end
+  end
+end

--- a/lib/http/headers/known.rb
+++ b/lib/http/headers/known.rb
@@ -68,6 +68,10 @@ module HTTP
     # Currently defined methods are: chunked, compress, deflate, gzip, identity.
     TRANSFER_ENCODING = "Transfer-Encoding".freeze
 
+    # Indicates what additional content codings have been applied to the
+    # entity-body.
+    CONTENT_ENCODING = "Content-Encoding".freeze
+
     # The user agent string of the user agent.
     USER_AGENT = "User-Agent".freeze
 

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -8,6 +8,7 @@ require "http/features/auto_inflate"
 require "http/features/auto_deflate"
 
 module HTTP
+  # rubocop:disable Metrics/ClassLength
   class Options
     @default_socket_class     = TCPSocket
     @default_ssl_socket_class = OpenSSL::SSL::SSLSocket

--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -15,18 +15,18 @@ module HTTP
       # @return [HTTP::Connection]
       attr_reader :connection
 
-      def initialize(connection, encoding = Encoding::BINARY, options = {})
+      def initialize(connection, stream, encoding = Encoding::BINARY)
         @connection = connection
         @streaming  = nil
         @contents   = nil
+        @stream     = stream
         @encoding   = encoding
-        @source     = options[:inflater] || connection
       end
 
       # (see HTTP::Client#readpartial)
       def readpartial(*args)
         stream!
-        @source.readpartial(*args)
+        @stream.readpartial(*args)
       end
 
       # Iterate over the body, allowing it to be enumerable
@@ -53,7 +53,7 @@ module HTTP
           @streaming  = false
           @contents   = String.new("").force_encoding(encoding)
 
-          while (chunk = @source.readpartial)
+          while (chunk = @stream.readpartial)
             @contents << chunk.force_encoding(encoding)
           end
         rescue

--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -15,17 +15,18 @@ module HTTP
       # @return [HTTP::Connection]
       attr_reader :connection
 
-      def initialize(connection, encoding = Encoding::BINARY)
+      def initialize(connection, encoding = Encoding::BINARY, options = {})
         @connection = connection
         @streaming  = nil
         @contents   = nil
         @encoding   = encoding
+        @source     = options[:inflater] || connection
       end
 
       # (see HTTP::Client#readpartial)
       def readpartial(*args)
         stream!
-        @connection.readpartial(*args)
+        @source.readpartial(*args)
       end
 
       # Iterate over the body, allowing it to be enumerable
@@ -52,7 +53,7 @@ module HTTP
           @streaming  = false
           @contents   = String.new("").force_encoding(encoding)
 
-          while (chunk = @connection.readpartial)
+          while (chunk = @source.readpartial)
             @contents << chunk.force_encoding(encoding)
           end
         rescue

--- a/lib/http/response/inflater.rb
+++ b/lib/http/response/inflater.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+require "zlib"
+
 module HTTP
   class Response
     class Inflater

--- a/lib/http/response/inflater.rb
+++ b/lib/http/response/inflater.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module HTTP
+  class Response
+    class Inflater
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def readpartial(*args)
+        chunk = @connection.readpartial(*args)
+        if chunk
+          chunk = zstream.inflate(chunk)
+        elsif !zstream.closed?
+          zstream.finish
+          zstream.close
+        end
+        chunk
+      end
+
+      private
+
+      def zstream
+        @zstream ||= Zlib::Inflate.new(32 + Zlib::MAX_WBITS)
+      end
+    end
+  end
+end

--- a/spec/lib/http/features/auto_deflate_spec.rb
+++ b/spec/lib/http/features/auto_deflate_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+RSpec.describe HTTP::Features::AutoDeflate do
+  subject { HTTP::Features::AutoDeflate.new }
+
+  it "raises error for wrong type" do
+    expect { HTTP::Features::AutoDeflate.new(:method => :wrong) }.
+      to raise_error(HTTP::Error) { |error|
+        expect(error.message).to eq("Only gzip and deflate methods are supported")
+      }
+  end
+
+  it "accepts gzip method" do
+    expect(HTTP::Features::AutoDeflate.new(:method => :gzip).method).to eq "gzip"
+  end
+
+  it "accepts deflate method" do
+    expect(HTTP::Features::AutoDeflate.new(:method => :deflate).method).to eq "deflate"
+  end
+
+  it "accepts string as method" do
+    expect(HTTP::Features::AutoDeflate.new(:method => "gzip").method).to eq "gzip"
+  end
+
+  it "uses gzip by default" do
+    expect(subject.method).to eq("gzip")
+  end
+
+  describe "#deflate" do
+    let(:headers) { HTTP::Headers.coerce("Content-Length" => "10") }
+
+    context "when body is nil" do
+      let(:body) { nil }
+
+      it "returns nil" do
+        expect(subject.deflate(headers, body)).to be_nil
+      end
+
+      it "does not remove Content-Length header" do
+        subject.deflate(headers, body)
+        expect(headers["Content-Length"]).to eq "10"
+      end
+
+      it "does not set Content-Encoding header" do
+        subject.deflate(headers, body)
+        expect(headers.include?("Content-Encoding")).to eq false
+      end
+    end
+
+    context "when body is not a string" do
+      let(:body) { {} }
+
+      it "returns given body" do
+        expect(subject.deflate(headers, body).object_id).to eq(body.object_id)
+      end
+
+      it "does not remove Content-Length header" do
+        subject.deflate(headers, body)
+        expect(headers["Content-Length"]).to eq "10"
+      end
+
+      it "does not set Content-Encoding header" do
+        subject.deflate(headers, body)
+        expect(headers.include?("Content-Encoding")).to eq false
+      end
+    end
+
+    context "when body is a string" do
+      let(:body) { "Hello HTTP!" }
+
+      it "encodes body" do
+        encoded = subject.deflate(headers, body)
+        decoded = Zlib::GzipReader.new(StringIO.new(encoded)).read
+
+        expect(decoded).to eq(body)
+      end
+
+      it "removes Content-Length header" do
+        subject.deflate(headers, body)
+        expect(headers.include?("Content-Length")).to eq false
+      end
+
+      it "sets Content-Encoding header" do
+        subject.deflate(headers, body)
+        expect(headers["Content-Encoding"]).to eq "gzip"
+      end
+
+      context "as deflate method" do
+        subject { HTTP::Features::AutoDeflate.new(:method => :deflate) }
+
+        it "encodes body" do
+          encoded = subject.deflate(headers, body)
+          decoded = Zlib::Inflate.inflate(encoded)
+
+          expect(decoded).to eq(body)
+        end
+
+        it "removes Content-Length header" do
+          subject.deflate(headers, body)
+          expect(headers.include?("Content-Length")).to eq false
+        end
+
+        it "sets Content-Encoding header" do
+          subject.deflate(headers, body)
+          expect(headers["Content-Encoding"]).to eq "deflate"
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/http/features/auto_inflate_spec.rb
+++ b/spec/lib/http/features/auto_inflate_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+RSpec.describe HTTP::Features::AutoInflate do
+  subject { HTTP::Features::AutoInflate.new }
+  let(:connection) { double }
+  let(:headers) { {} }
+  let(:response) do
+    HTTP::Response.new(
+      :version    => "1.1",
+      :status     => 200,
+      :headers    => headers,
+      :connection => connection
+    )
+  end
+
+  describe "stream_for" do
+    context "when there is no Content-Encoding header" do
+      it "returns connection" do
+        stream = subject.stream_for(connection, response)
+        expect(stream).to eq(connection)
+      end
+    end
+
+    context "for identity Content-Encoding header" do
+      let(:headers) { {:content_encoding => "not-supported"} }
+
+      it "returns connection" do
+        stream = subject.stream_for(connection, response)
+        expect(stream).to eq(connection)
+      end
+    end
+
+    context "for unknown Content-Encoding header" do
+      let(:headers) { {:content_encoding => "not-supported"} }
+
+      it "returns connection" do
+        stream = subject.stream_for(connection, response)
+        expect(stream).to eq(connection)
+      end
+    end
+
+    context "for deflate Content-Encoding header" do
+      let(:headers) { {:content_encoding => "deflate"} }
+
+      it "returns HTTP::Response::Inflater instance - connection wrapper" do
+        stream = subject.stream_for(connection, response)
+        expect(stream).to be_instance_of HTTP::Response::Inflater
+      end
+    end
+
+    context "for gzip Content-Encoding header" do
+      let(:headers) { {:content_encoding => "gzip"} }
+
+      it "returns HTTP::Response::Inflater instance - connection wrapper" do
+        stream = subject.stream_for(connection, response)
+        expect(stream).to be_instance_of HTTP::Response::Inflater
+      end
+    end
+
+    context "for x-gzip Content-Encoding header" do
+      let(:headers) { {:content_encoding => "x-gzip"} }
+
+      it "returns HTTP::Response::Inflater instance - connection wrapper" do
+        stream = subject.stream_for(connection, response)
+        expect(stream).to be_instance_of HTTP::Response::Inflater
+      end
+    end
+  end
+end

--- a/spec/lib/http/options/features_spec.rb
+++ b/spec/lib/http/options/features_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+RSpec.describe HTTP::Options, "features" do
+  let(:opts) { HTTP::Options.new }
+
+  it "defaults to be empty" do
+    expect(opts.features).to be_empty
+  end
+
+  it "accepts plain symbols in array" do
+    opts2 = opts.with_features([:auto_inflate])
+    expect(opts.features).to be_empty
+    expect(opts2.features.keys).to eq([:auto_inflate])
+    expect(opts2.features[:auto_inflate]).
+      to be_instance_of(HTTP::Features::AutoInflate)
+  end
+
+  it "accepts feature name with its options in array" do
+    opts2 = opts.with_features([{:auto_deflate => {:method => :deflate}}])
+    expect(opts.features).to be_empty
+    expect(opts2.features.keys).to eq([:auto_deflate])
+    expect(opts2.features[:auto_deflate]).
+      to be_instance_of(HTTP::Features::AutoDeflate)
+    expect(opts2.features[:auto_deflate].method).to eq("deflate")
+  end
+
+  it "raises error for not supported features" do
+    expect { opts.with_features([:wrong_feature]) }.
+      to raise_error(HTTP::Error) { |error|
+        expect(error.message).to eq("Unsupported feature: wrong_feature")
+      }
+  end
+end

--- a/spec/lib/http/options/merge_spec.rb
+++ b/spec/lib/http/options/merge_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe HTTP::Options, "merge" do
       :body      => "body-foo",
       :json      => {:foo => "foo"},
       :headers   => {:accept => "json", :foo => "foo"},
-      :proxy     => {}
+      :proxy     => {},
+      :features  => {}
     )
 
     bar = HTTP::Options.new(
@@ -60,7 +61,8 @@ RSpec.describe HTTP::Options, "merge" do
       :ssl_socket_class   => described_class.default_ssl_socket_class,
       :ssl_context        => nil,
       :cookies            => {},
-      :encoding           => nil
+      :encoding           => nil,
+      :features           => {}
     )
   end
 end

--- a/spec/lib/http/response/body_spec.rb
+++ b/spec/lib/http/response/body_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe HTTP::Response::Body do
 
   before           { allow(connection).to receive(:readpartial) { chunks.shift } }
 
-  subject(:body)   { described_class.new(connection, Encoding::UTF_8) }
+  subject(:body)   { described_class.new(connection, connection, Encoding::UTF_8) }
 
   it "streams bodies from responses" do
     expect(subject.to_s).to eq("Hello, World!")
@@ -47,7 +47,7 @@ RSpec.describe HTTP::Response::Body do
     end
     subject(:body) do
       inflater = HTTP::Response::Inflater.new(connection)
-      described_class.new(connection, Encoding::UTF_8, :inflater => inflater)
+      described_class.new(connection, inflater, Encoding::UTF_8)
     end
 
     it "decodes body" do

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe HTTP do
         expect(response.to_s).to eq("#{body}-raw")
       end
 
-      it "returns returns decoded body" do
+      it "returns decoded body" do
         client   = HTTP.use(:auto_inflate).headers("Accept-Encoding" => "gzip")
         body     = "Hello!"
         response = client.post("#{dummy.endpoint}/encoded-body", :body => body)

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -2,6 +2,7 @@
 # encoding: UTF-8
 
 class DummyServer < WEBrick::HTTPServer
+  # rubocop:disable Metrics/ClassLength
   class Servlet < WEBrick::HTTPServlet::AbstractServlet
     def self.sockets
       @sockets ||= []

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -158,8 +158,8 @@ class DummyServer < WEBrick::HTTPServer
                      Zlib::GzipWriter.wrap(out) do |gz|
                        gz.write "#{req.body}-gzipped"
                        gz.finish
+                       out.tap(&:rewind).read
                      end
-                     out.tap(&:rewind).read
                    end
                  when "deflate" then
                    res["Content-Encoding"] = "deflate"


### PR DESCRIPTION
Hi,

I implemented gzip/inflate decompression. It resolves #113.

Before:

```
HTTP.headers('Accept-Encoding' => 'gzip').get("https://github.com").to_s[0,12]
 => "\u001F\x8B\b\u0000\u0000\u0000\u0000\u0000\u0000\u0003\xED]"
```

After:

```
HTTP.headers('Accept-Encoding' => 'gzip').get("https://github.com").to_s[0,12]
=> "\n\n\n<!DOCTYPE"
```

Please, let me know if I need to change something here.
