### PR TITLE
Fixing up the #timeout docs on Chainable

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -75,10 +75,12 @@ module HTTP
       branch(options).request verb, uri
     end
 
-    # @overload(options = {})
+    # @overload timeout(options = {})
     #   Syntax sugar for `timeout(:per_operation, options)`
-    # @overload(klass, options = {})
+    # @overload timeout(klass, options = {})
+    #   Adds a timeout to the request.
     #   @param [#to_sym] klass
+    #     either :null, :global, or :per_operation
     #   @param [Hash] options
     #   @option options [Float] :read Read timeout
     #   @option options [Float] :write Write timeout


### PR DESCRIPTION
A minor typo makes it very difficult to parse the docs for the `#timeout` method: http://www.rubydoc.info/github/httprb/http/HTTP/Chainable#timeout-instance_method

This just correct the `@overload` declarations and adds a tiny bit more info.