### PR TITLE
Only run RuboCop on 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,18 @@ install: bundle _1.14.3_ install --without development doc
 
 script: bundle _1.14.3_ exec rake
 
-env:
-  global:
-    - JRUBY_OPTS="$JRUBY_OPTS --debug"
+# Only run RuboCop on the latest Ruby
+matrix:
+  fast_finish: true
+  include:
+  # Include JRuby first because it takes the longest
+  - rvm: jruby-9.1.7.0
+    env: RUBOCOP=false JRUBY_OPTS="$JRUBY_OPTS --debug"
+  # Only run RuboCop and Yardstick metrics on the latest Ruby
+  - rvm: 2.4.0
+    env: RUBOCOP=true METRICS=true
 
 rvm:
-  - jruby-9.1.7.0
   - 2.0.0
   - 2.1
   - 2.2
@@ -24,13 +30,6 @@ rvm:
 
 env:
   - RUBOCOP=false
-
-# Only run RuboCop on the latest Ruby
-matrix:
-  fast_finish: true
-  include:
-  - rvm: 2.4.0
-    env: RUBOCOP=true
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,16 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.3
-  - 2.4.0
 
+env:
+  - RUBOCOP=false
+
+# Only run RuboCop on the latest Ruby
 matrix:
   fast_finish: true
+  include:
+  - rvm: 2.4.0
+    env: RUBOCOP=true
 
 branches:
   only:

--- a/Rakefile
+++ b/Rakefile
@@ -6,13 +6,19 @@ RSpec::Core::RakeTask.new
 
 task :test => :spec
 
+run_rubocop = true unless ENV["RUBOCOP"] == false
+
 begin
   require "rubocop/rake_task"
-  RuboCop::RakeTask.new
 rescue LoadError
-  task :rubocop do
-    $stderr.puts "RuboCop is disabled"
-  end
+  warn "couldn't load RuboCop!"
+  run_rubocop = false
+end
+
+if run_rubocop
+  RuboCop::RakeTask.new
+else
+  task(:rubocop) { $stderr.puts "RuboCop is disabled" }
 end
 
 require "yardstick/rake/measurement"

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ RSpec::Core::RakeTask.new
 
 task :test => :spec
 
-run_rubocop = true unless ENV["RUBOCOP"] == false
+run_rubocop = true unless ENV["RUBOCOP"] == "false"
 
 begin
   require "rubocop/rake_task"
@@ -74,4 +74,5 @@ task :generate_status_codes do
   end
 end
 
-task :default => [:spec, :rubocop, :verify_measurements]
+task :default => [:spec, :rubocop]
+Rake::Task[:default].enhance [:verify_measurements] if ENV["METRICS"] == "true"


### PR DESCRIPTION
Don't redundantly run RuboCop on every Ruby under the sun.

This will inadvertently fix the build as well. Woohoo! (Ok, not actually inadvertently)