### PR TITLE
Add URI#dup method to fix a bug with shared internal instance variables

### DIFF
--- a/lib/http/uri.rb
+++ b/lib/http/uri.rb
@@ -114,6 +114,11 @@ module HTTP
       HTTPS_SCHEME == scheme
     end
 
+    # @return [Object] duplicated URI
+    def dup
+      self.class.new @uri.dup
+    end
+
     # Convert an HTTP::URI to a String
     #
     # @return [String] URI serialized as a String

--- a/spec/lib/http/uri_spec.rb
+++ b/spec/lib/http/uri_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe HTTP::URI do
   it "sets default ports for HTTPS URIs" do
     expect(https_uri.port).to eq 443
   end
+
+  describe "#dup" do
+    it "doesn't share internal value between duplicates" do
+      duplicated_uri = http_uri.dup
+      duplicated_uri.host = "example.org"
+
+      expect(duplicated_uri.to_s).to eq("http://example.org")
+      expect(http_uri.to_s).to eq("http://example.com")
+    end
+  end
 end


### PR DESCRIPTION
Resolves #388.