### PR TITLE
Make keep_alive_timeout configurable

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -109,12 +109,13 @@ module HTTP
       )
     end
 
-    # @overload persistent(host)
+    # @overload persistent(host, timeout: nil)
     #   Flags as persistent
-    #   @param [String] host
-    #   @raise [Request::Error] if Host is invalid
+    #   @param  [String] host
+    #   @option [Integer] timeout Keep alive timeout
+    #   @raise  [Request::Error] if Host is invalid
     #   @return [HTTP::Client] Persistent client
-    # @overload persistent(host, &block)
+    # @overload persistent(host, timeout: nil, &block)
     #   Executes given block with persistent client and automatically closes
     #   connection at the end of execution.
     #
@@ -138,8 +139,10 @@ module HTTP
     #
     #   @yieldparam [HTTP::Client] client Persistent client
     #   @return [Object] result of last expression in the block
-    def persistent(host)
-      p_client = branch default_options.with_persistent host
+    def persistent(host, timeout: nil)
+      opts = {}
+      opts[:keep_alive_timeout] = timeout if timeout
+      p_client = branch default_options.merge(opts).with_persistent host
       return p_client unless block_given?
       yield p_client
     ensure

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -1,5 +1,5 @@
+# coding: utf-8
 # frozen_string_literal: true
-# encoding: utf-8
 
 require "json"
 
@@ -286,6 +286,14 @@ RSpec.describe HTTP do
           expect(client).to receive(:close).and_call_original
           client.get("/repos/httprb/http.rb")
         end
+      end
+    end
+
+    context "with timeout specified" do
+      subject(:client) { HTTP.persistent host, :timeout => 100 }
+      it "sets keep_alive_timeout" do
+        options = client.default_options
+        expect(options.keep_alive_timeout).to eq(100)
       end
     end
   end


### PR DESCRIPTION
Allow keep_alive_timeout to be set in persistent:

HTTP.persistent("http...", timeout: 120)