### PR TITLE
Enable request body streaming with an IO object

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.0"
 
   gem.add_runtime_dependency "http_parser.rb", "~> 0.6.0"
-  gem.add_runtime_dependency "http-form_data", "~> 1.0.1"
+  gem.add_runtime_dependency "http-form_data", ">= 2.0.0-pre2", "< 3"
   gem.add_runtime_dependency "http-cookie",    "~> 1.0"
   gem.add_runtime_dependency "addressable",    "~> 2.3"
 

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -157,9 +157,8 @@ module HTTP
           opts.body
         when opts.form
           form = HTTP::FormData.create opts.form
-          headers[Headers::CONTENT_TYPE]   ||= form.content_type
-          headers[Headers::CONTENT_LENGTH] ||= form.content_length
-          form.to_s
+          headers[Headers::CONTENT_TYPE] ||= form.content_type
+          form
         when opts.json
           body = MimeType[:json].encode opts.json
           headers[Headers::CONTENT_TYPE] ||= "application/json; charset=#{body.encoding.name}"

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -74,7 +74,7 @@ module HTTP
     # @option opts [HTTP::URI, #to_s] :uri
     # @option opts [Hash] :headers
     # @option opts [Hash] :proxy
-    # @option opts [String] :body
+    # @option opts [String, Enumerable, IO, nil] :body
     def initialize(opts)
       @verb   = opts.fetch(:verb).to_s.downcase.to_sym
       @uri    = normalize_uri(opts.fetch(:uri))

--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -3,9 +3,6 @@
 module HTTP
   class Request
     class Body
-      # Types valid to be used as body source
-      VALID_BODY_TYPES = [String, NilClass, Enumerable].freeze
-
       # Maximum chunk size used for reading content of an IO
       BUFFER_SIZE = Connection::BUFFER_SIZE
 
@@ -46,7 +43,11 @@ module HTTP
       private
 
       def validate_body_type!
-        return if VALID_BODY_TYPES.any? { |type| @body.is_a? type }
+        return if @body.is_a?(String)
+        return if @body.respond_to?(:read)
+        return if @body.is_a?(Enumerable)
+        return if @body.nil?
+
         raise RequestError, "body of wrong type: #{@body.class}"
       end
     end

--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -33,8 +33,10 @@ module HTTP
         if @body.is_a?(String)
           yield @body
         elsif @body.respond_to?(:read)
-          chunk = String.new # rubocop:disable Style/EmptyLiteral
-          yield chunk while @body.read(BUFFER_SIZE, chunk)
+          loop do
+            data = @body.read(BUFFER_SIZE) or break
+            yield data
+          end
         elsif @body.is_a?(Enumerable)
           @body.each { |chunk| yield chunk }
         end

--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -33,8 +33,7 @@ module HTTP
         if @body.is_a?(String)
           yield @body
         elsif @body.respond_to?(:read)
-          loop do
-            data = @body.read(BUFFER_SIZE) or break
+          while (data = @body.read(BUFFER_SIZE))
             yield data
           end
         elsif @body.is_a?(Enumerable)

--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -13,6 +13,8 @@ module HTTP
       end
 
       # Returns size which should be used for the "Content-Length" header.
+      #
+      # @return [Integer]
       def size
         if @body.is_a?(String)
           @body.bytesize
@@ -27,6 +29,8 @@ module HTTP
       end
 
       # Yields chunks of content to be streamed to the request body.
+      #
+      # @yieldparam [String]
       def each
         return enum_for(__method__) unless block_given?
 

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -56,6 +56,7 @@ module HTTP
         if @body.is_a?(String)
           @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.bytesize}"
         elsif @body.respond_to?(:read)
+          raise(RequestError, "IO object must respond to #size") unless @body.respond_to?(:size)
           @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.size}"
         elsif @body.nil?
           @request_header << "#{Headers::CONTENT_LENGTH}: 0"

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -47,9 +47,9 @@ module HTTP
       # Adds the headers to the header array for the given request body we are working
       # with
       def add_body_type_headers
-        unless @headers[Headers::CONTENT_LENGTH] || chunked?
-          @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.size}"
-        end
+        return if @headers[Headers::CONTENT_LENGTH] || chunked?
+
+        @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.size}"
       end
 
       # Joins the headers specified in the request into a correctly formatted

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -51,16 +51,16 @@ module HTTP
       # Adds the headers to the header array for the given request body we are working
       # with
       def add_body_type_headers
-        unless @headers[Headers::CONTENT_LENGTH]
-          if @body.is_a?(String)
-            @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.bytesize}"
-          elsif @body.respond_to?(:read)
-            @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.size}"
-          elsif @body.nil?
-            @request_header << "#{Headers::CONTENT_LENGTH}: 0"
-          elsif @body.is_a?(Enumerable) && CHUNKED != @headers[Headers::TRANSFER_ENCODING]
-            raise(RequestError, "invalid transfer encoding")
-          end
+        return if @headers[Headers::CONTENT_LENGTH]
+
+        if @body.is_a?(String)
+          @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.bytesize}"
+        elsif @body.respond_to?(:read)
+          @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.size}"
+        elsif @body.nil?
+          @request_header << "#{Headers::CONTENT_LENGTH}: 0"
+        elsif @body.is_a?(Enumerable) && CHUNKED != @headers[Headers::TRANSFER_ENCODING]
+          raise(RequestError, "invalid transfer encoding")
         end
       end
 

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -158,6 +158,32 @@ RSpec.describe HTTP::Client do
     end
   end
 
+  describe "passing multipart form data" do
+    it "creates url encoded form data object" do
+      client = HTTP::Client.new
+      allow(client).to receive(:perform)
+
+      expect(HTTP::Request).to receive(:new) do |opts|
+        expect(opts[:body]).to be_a(HTTP::FormData::Urlencoded)
+        expect(opts[:body].to_s).to eq "foo=bar"
+      end
+
+      client.get("http://example.com/", :form => {:foo => "bar"})
+    end
+
+    it "creates multipart form data object" do
+      client = HTTP::Client.new
+      allow(client).to receive(:perform)
+
+      expect(HTTP::Request).to receive(:new) do |opts|
+        expect(opts[:body]).to be_a(HTTP::FormData::Multipart)
+        expect(opts[:body].to_s).to include("content")
+      end
+
+      client.get("http://example.com/", :form => {:foo => HTTP::FormData::Part.new("content")})
+    end
+  end
+
   describe "passing json" do
     it "encodes given object" do
       client = HTTP::Client.new

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe HTTP::Request::Writer do
         expect(io.string).to eq [
           "#{headerstart}\r\n",
           "Host: example.org\r\nContent-Length: 7\r\n\r\n",
-          "content",
+          "content"
         ].join
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe HTTP::Request::Writer do
         expect(io.string).to eq [
           "#{headerstart}\r\n",
           "Content-Length: 21\r\n\r\n",
-          "Привет, мир!",
+          "Привет, мир!"
         ].join
       end
 
@@ -86,7 +86,7 @@ RSpec.describe HTTP::Request::Writer do
           expect(io.string).to eq [
             "#{headerstart}\r\n",
             "Transfer-Encoding: chunked\r\n\r\n",
-            "15\r\nПривет, мир!\r\n0\r\n\r\n",
+            "15\r\nПривет, мир!\r\n0\r\n\r\n"
           ].join
         end
       end
@@ -99,7 +99,7 @@ RSpec.describe HTTP::Request::Writer do
           expect(io.string).to eq [
             "#{headerstart}\r\n",
             "Content-Length: 12\r\n\r\n",
-            "Привет, мир!",
+            "Привет, мир!"
           ].join
         end
       end
@@ -114,7 +114,7 @@ RSpec.describe HTTP::Request::Writer do
         expect(io.string).to eq [
           "#{headerstart}\r\n",
           "Content-Length: 8\r\n\r\n",
-          "beescows",
+          "beescows"
         ].join
       end
 
@@ -134,7 +134,7 @@ RSpec.describe HTTP::Request::Writer do
           writer.stream
           expect(io.string).to eq [
             "#{headerstart}\r\n",
-            "Content-Length: 0\r\n\r\n",
+            "Content-Length: 0\r\n\r\n"
           ].join
         end
       end
@@ -147,7 +147,7 @@ RSpec.describe HTTP::Request::Writer do
           expect(io.string).to eq [
             "#{headerstart}\r\n",
             "Transfer-Encoding: chunked\r\n\r\n",
-            "4\r\nbees\r\n4\r\ncows\r\n0\r\n\r\n",
+            "4\r\nbees\r\n4\r\ncows\r\n0\r\n\r\n"
           ].join
         end
       end
@@ -161,7 +161,7 @@ RSpec.describe HTTP::Request::Writer do
         expect(io.string).to eq [
           "#{headerstart}\r\n",
           "Content-Length: #{body.size}\r\n\r\n",
-          body.string,
+          body.string
         ].join
       end
 
@@ -177,7 +177,7 @@ RSpec.describe HTTP::Request::Writer do
           writer.stream
           expect(io.string).to eq [
             "#{headerstart}\r\n",
-            "Content-Length: 0\r\n\r\n",
+            "Content-Length: 0\r\n\r\n"
           ].join
         end
       end
@@ -190,7 +190,7 @@ RSpec.describe HTTP::Request::Writer do
           expect(io.string).to eq [
             "#{headerstart}\r\n",
             "Transfer-Encoding: chunked\r\n\r\n",
-            "4000\r\n#{"a" * 16 * 1024}\r\n2800\r\n#{"b" * 10 * 1024}\r\n0\r\n\r\n",
+            "4000\r\n#{'a' * 16 * 1024}\r\n2800\r\n#{'b' * 10 * 1024}\r\n0\r\n\r\n"
           ].join
         end
 
@@ -208,7 +208,7 @@ RSpec.describe HTTP::Request::Writer do
           expect(io.string).to eq [
             "#{headerstart}\r\n",
             "Content-Length: 12\r\n\r\n",
-            body.string,
+            body.string
           ].join
         end
 
@@ -227,7 +227,7 @@ RSpec.describe HTTP::Request::Writer do
         expect(io.string).to eq [
           "#{headerstart}\r\n",
           "Content-Length: #{body.size}\r\n\r\n",
-          body.string,
+          body.string
         ].join
       end
 
@@ -243,7 +243,7 @@ RSpec.describe HTTP::Request::Writer do
           writer.stream
           expect(io.string).to eq [
             "#{headerstart}\r\n",
-            "Content-Length: 0\r\n\r\n",
+            "Content-Length: 0\r\n\r\n"
           ].join
         end
       end
@@ -256,7 +256,7 @@ RSpec.describe HTTP::Request::Writer do
           expect(io.string).to eq [
             "#{headerstart}\r\n",
             "Transfer-Encoding: chunked\r\n\r\n",
-            "4000\r\n#{"a" * 16 * 1024}\r\n2800\r\n#{"b" * 10 * 1024}\r\n0\r\n\r\n",
+            "4000\r\n#{'a' * 16 * 1024}\r\n2800\r\n#{'b' * 10 * 1024}\r\n0\r\n\r\n"
           ].join
         end
 
@@ -274,7 +274,7 @@ RSpec.describe HTTP::Request::Writer do
           expect(io.string).to eq [
             "#{headerstart}\r\n",
             "Content-Length: 12\r\n\r\n",
-            body.string,
+            body.string
           ].join
         end
 
@@ -292,7 +292,7 @@ RSpec.describe HTTP::Request::Writer do
         writer.stream
         expect(io.string).to eq [
           "#{headerstart}\r\n",
-          "Content-Length: 0\r\n\r\n",
+          "Content-Length: 0\r\n\r\n"
         ].join
       end
 
@@ -304,7 +304,7 @@ RSpec.describe HTTP::Request::Writer do
           expect(io.string).to eq [
             "#{headerstart}\r\n",
             "Transfer-Encoding: chunked\r\n\r\n",
-            "0\r\n\r\n",
+            "0\r\n\r\n"
           ].join
         end
       end
@@ -316,7 +316,7 @@ RSpec.describe HTTP::Request::Writer do
           writer.stream
           expect(io.string).to eq [
             "#{headerstart}\r\n",
-            "Content-Length: 12\r\n\r\n",
+            "Content-Length: 12\r\n\r\n"
           ].join
         end
       end

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -170,6 +170,18 @@ RSpec.describe HTTP::Request::Writer do
         expect { writer.stream }.to raise_error(HTTP::RequestError)
       end
 
+      context "when IO is empty" do
+        let(:body) { FakeIO.new("") }
+
+        it "doesn't write anything" do
+          writer.stream
+          expect(io.string).to eq [
+            "#{headerstart}\r\n",
+            "Content-Length: 0\r\n\r\n",
+          ].join
+        end
+      end
+
       context "when Transfer-Encoding is chunked" do
         let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
 
@@ -222,6 +234,18 @@ RSpec.describe HTTP::Request::Writer do
       it "raises error when IO object doesn't respond to #size" do
         body.instance_eval { undef size }
         expect { writer.stream }.to raise_error(HTTP::RequestError)
+      end
+
+      context "when IO is empty" do
+        let(:body) { StringIO.new("") }
+
+        it "doesn't write anything" do
+          writer.stream
+          expect(io.string).to eq [
+            "#{headerstart}\r\n",
+            "Content-Length: 0\r\n\r\n",
+          ].join
+        end
       end
 
       context "when Transfer-Encoding is chunked" do

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe HTTP::Request::Writer do
 
   subject(:writer)  { described_class.new(io, body, headers, headerstart) }
 
-  describe "#initalize" do
+  describe "#initialize" do
     context "when body is nil" do
       let(:body) { nil }
 

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -121,6 +121,11 @@ RSpec.describe HTTP::Request::Writer do
         expect(io.string).to start_with "#{headerstart}\r\nContent-Length: #{1024 * 1024}\r\n\r\n"
       end
 
+      it "raises error when IO object doesn't respond to #size" do
+        body.instance_eval { undef size }
+        expect { writer.stream }.to raise_error(HTTP::RequestError)
+      end
+
       it "writes all data to the socket" do
         writer.stream
         expect(io.string).to end_with("a" * 1024 * 1024)

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe HTTP::Request::Writer do
       end
     end
 
-    context "when body is not string, enumerable or nil" do
+    context "when body is of unrecognized type" do
       let(:body) { 123 }
 
       it "raises an error" do
@@ -52,73 +52,117 @@ RSpec.describe HTTP::Request::Writer do
   end
 
   describe "#stream" do
-    context "when body is Enumerable" do
-      let(:body)    { %w(bees cows) }
-      let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
+    context "when multiple headers are set" do
+      let(:body) { "content" }
+      let(:headers) { HTTP::Headers.coerce "Host" => "example.org" }
 
-      it "writes a chunked request from an Enumerable correctly" do
+      it "separates headers with carriage return and line feed" do
         writer.stream
-        expect(io.string).to end_with "\r\n4\r\nbees\r\n4\r\ncows\r\n0\r\n\r\n"
-      end
-
-      it "writes Transfer-Encoding header only once" do
-        writer.stream
-        expect(io.string).to start_with "#{headerstart}\r\nTransfer-Encoding: chunked\r\n\r\n"
-      end
-
-      context "when Transfer-Encoding not set" do
-        let(:headers) { HTTP::Headers.new }
-        specify { expect { writer.stream }.to raise_error(HTTP::RequestError) }
-      end
-
-      context "when Transfer-Encoding is not chunked" do
-        let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "gzip" }
-        specify { expect { writer.stream }.to raise_error(HTTP::RequestError) }
+        expect(io.string).to eq [
+          "#{headerstart}\r\n",
+          "Host: example.org\r\nContent-Length: 7\r\n\r\n",
+          "content",
+        ].join
       end
     end
 
-    context "when body is nil" do
-      let(:body) { nil }
+    context "when body is a String" do
+      let(:body) { "Привет, мир!" }
 
-      it "properly sets Content-Length header if needed" do
+      it "writes content and sets Content-Length" do
         writer.stream
-        expect(io.string).to start_with "#{headerstart}\r\nContent-Length: 0\r\n\r\n"
+        expect(io.string).to eq [
+          "#{headerstart}\r\n",
+          "Content-Length: 21\r\n\r\n",
+          "Привет, мир!",
+        ].join
+      end
+
+      context "when Transfer-Encoding is chunked" do
+        let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
+
+        it "writes encoded content and omits Content-Length" do
+          writer.stream
+          expect(io.string).to eq [
+            "#{headerstart}\r\n",
+            "Transfer-Encoding: chunked\r\n\r\n",
+            "15\r\nПривет, мир!\r\n0\r\n\r\n",
+          ].join
+        end
       end
 
       context "when Content-Length explicitly set" do
         let(:headers) { HTTP::Headers.coerce "Content-Length" => 12 }
 
-        it "keeps given value" do
+        it "keeps Content-Length" do
           writer.stream
-          expect(io.string).to start_with "#{headerstart}\r\nContent-Length: 12\r\n\r\n"
+          expect(io.string).to eq [
+            "#{headerstart}\r\n",
+            "Content-Length: 12\r\n\r\n",
+            "Привет, мир!",
+          ].join
         end
       end
     end
 
-    context "when body is a unicode String" do
-      let(:body) { "Привет, мир!" }
+    context "when body is Enumerable" do
+      let(:body)    { %w(bees cows) }
+      let(:headers) { HTTP::Headers.coerce "Content-Length" => 8 }
 
-      it "properly calculates Content-Length if needed" do
+      it "writes content and sets Content-Length" do
         writer.stream
-        expect(io.string).to start_with "#{headerstart}\r\nContent-Length: 21\r\n\r\n"
+        expect(io.string).to eq [
+          "#{headerstart}\r\n",
+          "Content-Length: 8\r\n\r\n",
+          "beescows",
+        ].join
       end
 
-      context "when Content-Length explicitly set" do
-        let(:headers) { HTTP::Headers.coerce "Content-Length" => 12 }
+      context "when Content-Length is not set" do
+        let(:headers) { HTTP::Headers.new }
 
-        it "keeps given value" do
+        it "raises an error" do
+          expect { writer.stream }.to raise_error(HTTP::RequestError)
+        end
+      end
+
+      context "when Enumerable is empty" do
+        let(:body)    { %w() }
+        let(:headers) { HTTP::Headers.coerce "Content-Length" => 0 }
+
+        it "doesn't write anything" do
           writer.stream
-          expect(io.string).to start_with "#{headerstart}\r\nContent-Length: 12\r\n\r\n"
+          expect(io.string).to eq [
+            "#{headerstart}\r\n",
+            "Content-Length: 0\r\n\r\n",
+          ].join
+        end
+      end
+
+      context "when Transfer-Encoding is chunked" do
+        let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
+
+        it "writes encoded content and doesn't require Content-Length" do
+          writer.stream
+          expect(io.string).to eq [
+            "#{headerstart}\r\n",
+            "Transfer-Encoding: chunked\r\n\r\n",
+            "4\r\nbees\r\n4\r\ncows\r\n0\r\n\r\n",
+          ].join
         end
       end
     end
 
     context "when body is an IO" do
-      let(:body) { StringIO.new("a" * 1024 * 1024) }
+      let(:body) { StringIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
 
-      it "properly calculates Content-Length if needed" do
+      it "writes content and sets Content-Length" do
         writer.stream
-        expect(io.string).to start_with "#{headerstart}\r\nContent-Length: #{1024 * 1024}\r\n\r\n"
+        expect(io.string).to eq [
+          "#{headerstart}\r\n",
+          "Content-Length: #{body.size}\r\n\r\n",
+          body.string,
+        ].join
       end
 
       it "raises error when IO object doesn't respond to #size" do
@@ -126,9 +170,22 @@ RSpec.describe HTTP::Request::Writer do
         expect { writer.stream }.to raise_error(HTTP::RequestError)
       end
 
-      it "writes all data to the socket" do
-        writer.stream
-        expect(io.string).to end_with("a" * 1024 * 1024)
+      context "when Transfer-Encoding is chunked" do
+        let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
+
+        it "writes encoded content and doesn't require Content-Length" do
+          writer.stream
+          expect(io.string).to eq [
+            "#{headerstart}\r\n",
+            "Transfer-Encoding: chunked\r\n\r\n",
+            "4000\r\n#{"a" * 16 * 1024}\r\n2800\r\n#{"b" * 10 * 1024}\r\n0\r\n\r\n",
+          ].join
+        end
+
+        it "doesn't require body to respond to #size" do
+          body.instance_eval { undef size }
+          writer.stream
+        end
       end
 
       context "when Content-Length explicitly set" do
@@ -136,7 +193,53 @@ RSpec.describe HTTP::Request::Writer do
 
         it "keeps given value" do
           writer.stream
-          expect(io.string).to start_with "#{headerstart}\r\nContent-Length: 12\r\n\r\n"
+          expect(io.string).to eq [
+            "#{headerstart}\r\n",
+            "Content-Length: 12\r\n\r\n",
+            body.string,
+          ].join
+        end
+
+        it "doesn't require body to respond to #size" do
+          body.instance_eval { undef size }
+          writer.stream
+        end
+      end
+    end
+
+    context "when body is nil" do
+      let(:body) { nil }
+
+      it "writes empty content and sets Content-Length" do
+        writer.stream
+        expect(io.string).to eq [
+          "#{headerstart}\r\n",
+          "Content-Length: 0\r\n\r\n",
+        ].join
+      end
+
+      context "when Transfer-Encoding is chunked" do
+        let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
+
+        it "writes empty content and doesn't require Content-Length" do
+          writer.stream
+          expect(io.string).to eq [
+            "#{headerstart}\r\n",
+            "Transfer-Encoding: chunked\r\n\r\n",
+            "0\r\n\r\n",
+          ].join
+        end
+      end
+
+      context "when Content-Length explicitly set" do
+        let(:headers) { HTTP::Headers.coerce "Content-Length" => 12 }
+
+        it "keeps given value" do
+          writer.stream
+          expect(io.string).to eq [
+            "#{headerstart}\r\n",
+            "Content-Length: 12\r\n\r\n",
+          ].join
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ end
 require "http"
 require "rspec/its"
 require "support/capture_warning"
+require "support/fakeio"
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|

--- a/spec/support/fakeio.rb
+++ b/spec/support/fakeio.rb
@@ -1,0 +1,19 @@
+require "stringio"
+
+class FakeIO
+  def initialize(content)
+    @io = StringIO.new(content)
+  end
+
+  def string
+    @io.string
+  end
+
+  def read(*args)
+    @io.read(*args)
+  end
+
+  def size
+    @io.size
+  end
+end


### PR DESCRIPTION
This change adds the ability to stream content of an IO object (an object that responds to #read) into the request body. This is convenient when you want to send large amounts of data as the request body, but you don't want to load all of it into memory.

```rb
HTTP.post("http://example.org/upload", body: File.open("video.mp4"))
HTTP.post("http://example.org/upload", body: StringIO.new("file data"))
```

It was already possible to send the request body in chunks by passing an Enumerable to `:body`, but that can (and should) only be used for making "Transfer-Encoding: chunked" requests.

This will also allow us to extend form_data.rb to stream the multipart-encoded request, instead having to load the whole body into memory before writing it to the socket.