### PR TITLE
Let Host be automatically inferred on redirects

### DIFF
--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -94,7 +94,10 @@ module HTTP
 
     # Returns new Request with updated uri
     def redirect(uri, verb = @verb)
-      req = self.class.new(
+      headers = self.headers.dup
+      headers.delete(Headers::HOST)
+
+      self.class.new(
         :verb    => verb,
         :uri     => @uri.join(uri),
         :headers => headers,
@@ -102,9 +105,6 @@ module HTTP
         :body    => body,
         :version => version
       )
-
-      req[Headers::HOST] = req.uri.host
-      req
     end
 
     # Stream the request to a socket

--- a/spec/lib/http/request_spec.rb
+++ b/spec/lib/http/request_spec.rb
@@ -94,6 +94,20 @@ RSpec.describe HTTP::Request do
       expect(redirected["Host"]).to eq "blog.example.com"
     end
 
+    context "with URL with non-standard port given" do
+      subject(:redirected) { request.redirect "http://example.com:8080" }
+
+      its(:uri)     { is_expected.to eq HTTP::URI.parse "http://example.com:8080" }
+
+      its(:verb)    { is_expected.to eq request.verb }
+      its(:body)    { is_expected.to eq request.body }
+      its(:proxy)   { is_expected.to eq request.proxy }
+
+      it "presets new Host header" do
+        expect(redirected["Host"]).to eq "example.com:8080"
+      end
+    end
+
     context "with schema-less absolute URL given" do
       subject(:redirected) { request.redirect "//another.example.com/blog" }
 


### PR DESCRIPTION
When redirecting on `http://localhost:<port>` URLs, the Host will be correctly set to `http://localhost:<port>` on the initial request, but on following the redirect the port is lost, because we're only assigning the host.

Therefore when we initialize the follow-up request object we de-assign "Host", and let HTTP::Request set it in the same way as it is set on the initial request.

Since we're stubbing redirects at the moment, I didn't know how to write a test for this.