### PR TITLE
Make deflate work with any body

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,3 +78,6 @@ Style/StringLiterals:
 
 Style/TrivialAccessors:
   Enabled: false
+
+Performance/RedundantBlockCall:
+  Enabled: false

--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -57,7 +57,7 @@ module HTTP
         private
 
         def compress_all!
-          @compressed = Tempfile.new("http-compressed_body", binmode: true)
+          @compressed = Tempfile.new("http-compressed_body", :binmode => true)
           compress { |data| @compressed.write(data) }
           @compressed.rewind
         end

--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -90,10 +90,10 @@ module HTTP
           deflater = Zlib::Deflate.new
 
           @body.each do |chunk|
-            deflater.deflate(chunk) { |data| block.call(data) }
+            block.call deflater.deflate(chunk)
           end
 
-          deflater.finish { |data| block.call(data) }
+          block.call deflater.finish
         ensure
           deflater.close
         end

--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "zlib"
+require "tempfile"
 
 module HTTP
   module Features
@@ -15,29 +16,86 @@ module HTTP
         raise Error, "Only gzip and deflate methods are supported" unless %w(gzip deflate).include?(@method)
       end
 
-      def deflate(headers, body)
-        return body unless body
-        return body unless body.is_a?(String)
-
-        # We need to delete Content-Length header. It will be set automatically
-        # by HTTP::Request::Writer
-        headers.delete(Headers::CONTENT_LENGTH)
-
-        headers[Headers::CONTENT_ENCODING] = method
-
+      def deflated_body(body)
         case method
-        when "gzip" then
-          StringIO.open do |out|
-            Zlib::GzipWriter.wrap(out) do |gz|
-              gz.write body
-              gz.finish
-              out.tap(&:rewind).read
-            end
-          end
-        when "deflate" then
-          Zlib::Deflate.deflate(body)
+        when "gzip"
+          GzippedBody.new(body)
+        when "deflate"
+          DeflatedBody.new(body)
         else
           raise ArgumentError, "Unsupported deflate method: #{method}"
+        end
+      end
+
+      class CompressedBody
+        def initialize(body)
+          @body       = body
+          @compressed = nil
+        end
+
+        def size
+          compress_all! unless @compressed
+          @compressed.size
+        end
+
+        def each(&block)
+          return enum_for(__method__) unless block
+
+          if @compressed
+            begin
+              while (data = @compressed.read(Connection::BUFFER_SIZE))
+                block.call(data)
+              end
+            ensure
+              @compressed.close!
+            end
+          else
+            compress(&block)
+          end
+        end
+
+        private
+
+        def compress_all!
+          @compressed = Tempfile.new("http-compressed_body", binmode: true)
+          compress { |data| @compressed.write(data) }
+          @compressed.rewind
+        end
+      end
+
+      class GzippedBody < CompressedBody
+        def compress(&block)
+          gzip = Zlib::GzipWriter.new(BlockIO.new(block))
+
+          @body.each do |chunk|
+            gzip.write(chunk)
+          end
+        ensure
+          gzip.finish
+        end
+
+        class BlockIO
+          def initialize(block)
+            @block = block
+          end
+
+          def write(data)
+            @block.call(data)
+          end
+        end
+      end
+
+      class DeflatedBody < CompressedBody
+        def compress(&block)
+          deflater = Zlib::Deflate.new
+
+          @body.each do |chunk|
+            deflater.deflate(chunk) { |data| block.call(data) }
+          end
+
+          deflater.finish { |data| block.call(data) }
+        ensure
+          deflater.close
         end
       end
     end

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -5,6 +5,7 @@ require "time"
 
 require "http/errors"
 require "http/headers"
+require "http/request/body"
 require "http/request/writer"
 require "http/version"
 require "http/uri"
@@ -110,6 +111,7 @@ module HTTP
     # Stream the request to a socket
     def stream(socket)
       include_proxy_headers if using_proxy? && !@uri.https?
+      body = Request::Body.new(body)
       Request::Writer.new(socket, body, headers, headline).stream
     end
 

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "http/headers"
-require "http/request/body"
 
 module HTTP
   class Request
@@ -18,7 +17,7 @@ module HTTP
       CHUNKED_END = "#{ZERO}#{CRLF}#{CRLF}".freeze
 
       def initialize(socket, body, headers, headline)
-        @body           = Body.new(body)
+        @body           = body
         @socket         = socket
         @headers        = headers
         @request_header = [headline]

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -223,6 +223,27 @@ RSpec.describe HTTP::Client do
         client.request(:get, "http://example.com/")
       end
     end
+
+    context "when :auto_deflate was specified" do
+      let(:headers) { {"Content-Length" => "12"} }
+      let(:client)  { described_class.new :headers => headers, :features => {:auto_deflate => {}} }
+
+      it "deletes Content-Length header" do
+        expect(client).to receive(:perform) do |req, _|
+          expect(req["Content-Length"]).to eq nil
+        end
+
+        client.request(:get, "http://example.com/")
+      end
+
+      it "sets Content-Encoding header" do
+        expect(client).to receive(:perform) do |req, _|
+          expect(req["Content-Encoding"]).to eq "gzip"
+        end
+
+        client.request(:get, "http://example.com/")
+      end
+    end
   end
 
   include_context "HTTP handling" do

--- a/spec/lib/http/features/auto_deflate_spec.rb
+++ b/spec/lib/http/features/auto_deflate_spec.rb
@@ -26,14 +26,15 @@ RSpec.describe HTTP::Features::AutoDeflate do
   end
 
   describe "#deflated_body" do
-    let(:body)          { ["bees", "cows"] }
+    let(:body)          { %w(bees cows) }
     let(:deflated_body) { subject.deflated_body(body) }
 
     context "when method is gzip" do
       subject { HTTP::Features::AutoDeflate.new(:method => :gzip) }
 
       it "returns object which yields gzipped content of the given body" do
-        io = StringIO.new(String.new.force_encoding(Encoding::BINARY))
+        io = StringIO.new
+        io.set_encoding(Encoding::BINARY)
         gzip = Zlib::GzipWriter.new(io)
         gzip.write("beescows")
         gzip.close
@@ -43,7 +44,8 @@ RSpec.describe HTTP::Features::AutoDeflate do
       end
 
       it "caches compressed content when size is called" do
-        io = StringIO.new(String.new.force_encoding(Encoding::BINARY))
+        io = StringIO.new
+        io.set_encoding(Encoding::BINARY)
         gzip = Zlib::GzipWriter.new(io)
         gzip.write("beescows")
         gzip.close

--- a/spec/lib/http/request/body_spec.rb
+++ b/spec/lib/http/request/body_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe HTTP::Request::Body do
     end
 
     context "when body is an Enumerable" do
-      let(:body) { %w[bees cows] }
+      let(:body) { %w(bees cows) }
 
       it "raises a RequestError" do
         expect { subject.size }.to raise_error(HTTP::RequestError)
@@ -100,7 +100,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { "content" }
 
       it "yields the string" do
-        expect(subject.each.to_a).to eq ["content"]
+        expect(subject.each.to_a).to eq %w(content)
       end
     end
 
@@ -121,10 +121,10 @@ RSpec.describe HTTP::Request::Body do
     end
 
     context "when body is an Enumerable" do
-      let(:body) { %w[bees cows] }
+      let(:body) { %w(bees cows) }
 
       it "yields elements" do
-        expect(subject.each.to_a).to eq ["bees", "cows"]
+        expect(subject.each.to_a).to eq %w(bees cows)
       end
     end
   end

--- a/spec/lib/http/request/body_spec.rb
+++ b/spec/lib/http/request/body_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+RSpec.describe HTTP::Request::Body do
+  let(:body) { "" }
+  subject    { HTTP::Request::Body.new(body) }
+
+  describe "#initialize" do
+    context "when body is nil" do
+      let(:body) { nil }
+
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when body is a string" do
+      let(:body) { "string body" }
+
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when body is an IO" do
+      let(:body) { FakeIO.new("IO body") }
+
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when body is an Enumerable" do
+      let(:body) { %w(bees cows) }
+
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when body is of unrecognized type" do
+      let(:body) { 123 }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(HTTP::RequestError)
+      end
+    end
+  end
+
+  describe "#size" do
+    context "when body is nil" do
+      let(:body) { nil }
+
+      it "returns zero" do
+        expect(subject.size).to eq 0
+      end
+    end
+
+    context "when body is a string" do
+      let(:body) { "Привет, мир!" }
+
+      it "returns string bytesize" do
+        expect(subject.size).to eq 21
+      end
+    end
+
+    context "when body is an IO with size" do
+      let(:body) { FakeIO.new("content") }
+
+      it "returns IO size" do
+        expect(subject.size).to eq 7
+      end
+    end
+
+    context "when body is an IO without size" do
+      let(:body) { IO.pipe[0] }
+
+      it "raises a RequestError" do
+        expect { subject.size }.to raise_error(HTTP::RequestError)
+      end
+    end
+
+    context "when body is an Enumerable" do
+      let(:body) { %w[bees cows] }
+
+      it "raises a RequestError" do
+        expect { subject.size }.to raise_error(HTTP::RequestError)
+      end
+    end
+  end
+
+  describe "#each" do
+    context "when body is nil" do
+      let(:body) { nil }
+
+      it "yields nothing" do
+        expect(subject.each.to_a).to eq []
+      end
+    end
+
+    context "when body is a string" do
+      let(:body) { "content" }
+
+      it "yields the string" do
+        expect(subject.each.to_a).to eq ["content"]
+      end
+    end
+
+    context "when body is a non-Enumerable IO" do
+      let(:body) { FakeIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
+
+      it "yields chunks of content" do
+        expect(subject.each.to_a).to eq ["a" * 16 * 1024, "b" * 10 * 1024]
+      end
+    end
+
+    context "when body is an Enumerable IO" do
+      let(:body) { StringIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
+
+      it "yields chunks of content" do
+        expect(subject.each.to_a).to eq ["a" * 16 * 1024, "b" * 10 * 1024]
+      end
+    end
+
+    context "when body is an Enumerable" do
+      let(:body) { %w[bees cows] }
+
+      it "yields elements" do
+        expect(subject.each.to_a).to eq ["bees", "cows"]
+      end
+    end
+  end
+end

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe HTTP::Request::Writer do
 
     context "when Transfer-Encoding is chunked" do
       let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
-      let(:body)    { HTTP::Request::Body.new(["request", "body"]) }
+      let(:body)    { HTTP::Request::Body.new(%w(request body)) }
 
       it "writes encoded content and omits Content-Length" do
         writer.stream

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -3,322 +3,75 @@
 
 RSpec.describe HTTP::Request::Writer do
   let(:io)          { StringIO.new }
-  let(:body)        { "" }
+  let(:body)        { HTTP::Request::Body.new("") }
   let(:headers)     { HTTP::Headers.new }
   let(:headerstart) { "GET /test HTTP/1.1" }
 
   subject(:writer)  { described_class.new(io, body, headers, headerstart) }
 
-  describe "#initialize" do
-    context "when body is nil" do
-      let(:body) { nil }
-
-      it "does not raise an error" do
-        expect { writer }.not_to raise_error
-      end
-    end
-
-    context "when body is a string" do
-      let(:body) { "string body" }
-
-      it "does not raise an error" do
-        expect { writer }.not_to raise_error
-      end
-    end
-
-    context "when body is an IO" do
-      let(:body) { FakeIO.new("IO body") }
-
-      it "does not raise an error" do
-        expect { writer }.not_to raise_error
-      end
-    end
-
-    context "when body is an Enumerable" do
-      let(:body) { %w(bees cows) }
-
-      it "does not raise an error" do
-        expect { writer }.not_to raise_error
-      end
-    end
-
-    context "when body is of unrecognized type" do
-      let(:body) { 123 }
-
-      it "raises an error" do
-        expect { writer }.to raise_error(HTTP::RequestError)
-      end
-    end
-  end
-
   describe "#stream" do
     context "when multiple headers are set" do
-      let(:body) { "content" }
       let(:headers) { HTTP::Headers.coerce "Host" => "example.org" }
 
       it "separates headers with carriage return and line feed" do
         writer.stream
         expect(io.string).to eq [
           "#{headerstart}\r\n",
-          "Host: example.org\r\nContent-Length: 7\r\n\r\n",
+          "Host: example.org\r\nContent-Length: 0\r\n\r\n"
+        ].join
+      end
+    end
+
+    context "when body is nonempty" do
+      let(:body) { HTTP::Request::Body.new("content") }
+
+      it "writes it to the socket and sets Content-Length" do
+        writer.stream
+        expect(io.string).to eq [
+          "#{headerstart}\r\n",
+          "Content-Length: 7\r\n\r\n",
           "content"
         ].join
       end
     end
 
-    context "when body is a String" do
-      let(:body) { "Привет, мир!" }
+    context "when body is empty" do
+      let(:body) { HTTP::Request::Body.new(nil) }
 
-      it "writes content and sets Content-Length" do
-        writer.stream
-        expect(io.string).to eq [
-          "#{headerstart}\r\n",
-          "Content-Length: 21\r\n\r\n",
-          "Привет, мир!"
-        ].join
-      end
-
-      context "when Transfer-Encoding is chunked" do
-        let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
-
-        it "writes encoded content and omits Content-Length" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Transfer-Encoding: chunked\r\n\r\n",
-            "15\r\nПривет, мир!\r\n0\r\n\r\n"
-          ].join
-        end
-      end
-
-      context "when Content-Length explicitly set" do
-        let(:headers) { HTTP::Headers.coerce "Content-Length" => 12 }
-
-        it "keeps Content-Length" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Content-Length: 12\r\n\r\n",
-            "Привет, мир!"
-          ].join
-        end
-      end
-    end
-
-    context "when body is Enumerable" do
-      let(:body)    { %w(bees cows) }
-      let(:headers) { HTTP::Headers.coerce "Content-Length" => 8 }
-
-      it "writes content and sets Content-Length" do
-        writer.stream
-        expect(io.string).to eq [
-          "#{headerstart}\r\n",
-          "Content-Length: 8\r\n\r\n",
-          "beescows"
-        ].join
-      end
-
-      context "when Content-Length is not set" do
-        let(:headers) { HTTP::Headers.new }
-
-        it "raises an error" do
-          expect { writer.stream }.to raise_error(HTTP::RequestError)
-        end
-      end
-
-      context "when Enumerable is empty" do
-        let(:body)    { %w() }
-        let(:headers) { HTTP::Headers.coerce "Content-Length" => 0 }
-
-        it "doesn't write anything" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Content-Length: 0\r\n\r\n"
-          ].join
-        end
-      end
-
-      context "when Transfer-Encoding is chunked" do
-        let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
-
-        it "writes encoded content and doesn't require Content-Length" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Transfer-Encoding: chunked\r\n\r\n",
-            "4\r\nbees\r\n4\r\ncows\r\n0\r\n\r\n"
-          ].join
-        end
-      end
-    end
-
-    context "when body is an IO" do
-      let(:body) { FakeIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
-
-      it "writes content and sets Content-Length" do
-        writer.stream
-        expect(io.string).to eq [
-          "#{headerstart}\r\n",
-          "Content-Length: #{body.size}\r\n\r\n",
-          body.string
-        ].join
-      end
-
-      it "raises error when IO object doesn't respond to #size" do
-        body.instance_eval { undef size }
-        expect { writer.stream }.to raise_error(HTTP::RequestError)
-      end
-
-      context "when IO is empty" do
-        let(:body) { FakeIO.new("") }
-
-        it "doesn't write anything" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Content-Length: 0\r\n\r\n"
-          ].join
-        end
-      end
-
-      context "when Transfer-Encoding is chunked" do
-        let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
-
-        it "writes encoded content and doesn't require Content-Length" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Transfer-Encoding: chunked\r\n\r\n",
-            "4000\r\n#{'a' * 16 * 1024}\r\n2800\r\n#{'b' * 10 * 1024}\r\n0\r\n\r\n"
-          ].join
-        end
-
-        it "doesn't require body to respond to #size" do
-          body.instance_eval { undef size }
-          writer.stream
-        end
-      end
-
-      context "when Content-Length explicitly set" do
-        let(:headers) { HTTP::Headers.coerce "Content-Length" => 12 }
-
-        it "keeps given value" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Content-Length: 12\r\n\r\n",
-            body.string
-          ].join
-        end
-
-        it "doesn't require body to respond to #size" do
-          body.instance_eval { undef size }
-          writer.stream
-        end
-      end
-    end
-
-    context "when body is an Enumerable IO" do
-      let(:body) { StringIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
-
-      it "writes content and sets Content-Length" do
-        writer.stream
-        expect(io.string).to eq [
-          "#{headerstart}\r\n",
-          "Content-Length: #{body.size}\r\n\r\n",
-          body.string
-        ].join
-      end
-
-      it "raises error when IO object doesn't respond to #size" do
-        body.instance_eval { undef size }
-        expect { writer.stream }.to raise_error(HTTP::RequestError)
-      end
-
-      context "when IO is empty" do
-        let(:body) { StringIO.new("") }
-
-        it "doesn't write anything" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Content-Length: 0\r\n\r\n"
-          ].join
-        end
-      end
-
-      context "when Transfer-Encoding is chunked" do
-        let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
-
-        it "writes encoded content and doesn't require Content-Length" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Transfer-Encoding: chunked\r\n\r\n",
-            "4000\r\n#{'a' * 16 * 1024}\r\n2800\r\n#{'b' * 10 * 1024}\r\n0\r\n\r\n"
-          ].join
-        end
-
-        it "doesn't require body to respond to #size" do
-          body.instance_eval { undef size }
-          writer.stream
-        end
-      end
-
-      context "when Content-Length explicitly set" do
-        let(:headers) { HTTP::Headers.coerce "Content-Length" => 12 }
-
-        it "keeps given value" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Content-Length: 12\r\n\r\n",
-            body.string
-          ].join
-        end
-
-        it "doesn't require body to respond to #size" do
-          body.instance_eval { undef size }
-          writer.stream
-        end
-      end
-    end
-
-    context "when body is nil" do
-      let(:body) { nil }
-
-      it "writes empty content and sets Content-Length" do
+      it "doesn't write anything to the socket and sets Content-Length" do
         writer.stream
         expect(io.string).to eq [
           "#{headerstart}\r\n",
           "Content-Length: 0\r\n\r\n"
         ].join
       end
+    end
 
-      context "when Transfer-Encoding is chunked" do
-        let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
+    context "when Content-Length header is set" do
+      let(:headers) { HTTP::Headers.coerce "Content-Length" => "12" }
+      let(:body)    { HTTP::Request::Body.new("content") }
 
-        it "writes empty content and doesn't require Content-Length" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Transfer-Encoding: chunked\r\n\r\n",
-            "0\r\n\r\n"
-          ].join
-        end
+      it "keeps the given value" do
+        writer.stream
+        expect(io.string).to eq [
+          "#{headerstart}\r\n",
+          "Content-Length: 12\r\n\r\n",
+          "content"
+        ].join
       end
+    end
 
-      context "when Content-Length explicitly set" do
-        let(:headers) { HTTP::Headers.coerce "Content-Length" => 12 }
+    context "when Transfer-Encoding is chunked" do
+      let(:headers) { HTTP::Headers.coerce "Transfer-Encoding" => "chunked" }
+      let(:body)    { HTTP::Request::Body.new(["request", "body"]) }
 
-        it "keeps given value" do
-          writer.stream
-          expect(io.string).to eq [
-            "#{headerstart}\r\n",
-            "Content-Length: 12\r\n\r\n"
-          ].join
-        end
+      it "writes encoded content and omits Content-Length" do
+        writer.stream
+        expect(io.string).to eq [
+          "#{headerstart}\r\n",
+          "Transfer-Encoding: chunked\r\n\r\n",
+          "7\r\nrequest\r\n4\r\nbody\r\n0\r\n\r\n"
+        ].join
       end
     end
   end

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -429,6 +429,15 @@ RSpec.describe HTTP do
 
         expect(Zlib::GzipReader.new(StringIO.new(encoded)).read).to eq body
       end
+
+      it "sends deflated body" do
+        client   = HTTP.use :auto_deflate => {:method => "deflate"}
+        body     = "Hello!"
+        response = client.post("#{dummy.endpoint}/echo-body", :body => body)
+        encoded  = response.to_s
+
+        expect(Zlib::Inflate.inflate(encoded)).to eq body
+      end
     end
 
     context "with :auto_inflate" do


### PR DESCRIPTION
Currently auto deflating works only for string bodies, so we generalize the implementation to work with any request body (such as IO and Enumerable), by relying on the `Request::Body` abstraction. For that I had to first extract `Request::Body` outside of `Request::Writer`, so that `Request::Writer` doesn't have to know about deflating.

On "Transfer-Encoding: chunked" requests the compressed body will be directly streamed to the socket as it is deflated, while on regular requests all of the body has to be deflated first so that we can obtain the compressed body size for the "Content-Length" header before we start writing content.

~We also improve memory usage by yielding deflated chunks instead of returning the whole deflated body.~ (JRuby doesn't support it yet, see https://github.com/jruby/jruby/issues/2128)