### PR TITLE
Further upload improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,9 +78,3 @@ Style/StringLiterals:
 
 Style/TrivialAccessors:
   Enabled: false
-
-Lint/HandleExceptions:
-  Enabled: false
-
-Style/EmptyLiteral:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,3 +81,6 @@ Style/TrivialAccessors:
 
 Lint/HandleExceptions:
   Enabled: false
+
+Style/EmptyLiteral:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,3 +78,6 @@ Style/StringLiterals:
 
 Style/TrivialAccessors:
   Enabled: false
+
+Lint/HandleExceptions:
+  Enabled: false

--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -29,8 +29,6 @@ module HTTP
       #
       # @yieldparam [String]
       def each(&block)
-        return enum_for(__method__) unless block_given?
-
         if @body.is_a?(String)
           yield @body
         elsif @body.respond_to?(:read)

--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -32,7 +32,7 @@ module HTTP
         if @body.is_a?(String)
           yield @body
         elsif @body.respond_to?(:read)
-          IO.copy_stream(@body, BlockIO.new(block))
+          IO.copy_stream(@body, ProcIO.new(block))
         elsif @body.is_a?(Enumerable)
           @body.each(&block)
         end
@@ -49,7 +49,10 @@ module HTTP
         raise RequestError, "body of wrong type: #{@body.class}"
       end
 
-      class BlockIO
+      # This class provides a "writable IO" wrapper around a proc object, with
+      # #write simply calling the proc, which we can pass in as the
+      # "destination IO" in IO.copy_stream.
+      class ProcIO
         def initialize(block)
           @block = block
         end

--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -29,6 +29,8 @@ module HTTP
       #
       # @yieldparam [String]
       def each(&block)
+        return enum_for(__method__) unless block_given?
+
         if @body.is_a?(String)
           yield @body
         elsif @body.respond_to?(:read)

--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -34,7 +34,7 @@ module HTTP
         elsif @body.respond_to?(:read)
           IO.copy_stream(@body, BlockIO.new(block))
         elsif @body.is_a?(Enumerable)
-          @body.each { |chunk| yield chunk }
+          @body.each(&block)
         end
       end
 

--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -32,15 +32,14 @@ module HTTP
       #
       # @yieldparam [String]
       def each
-        return enum_for(__method__) unless block_given?
-
         if @body.is_a?(String)
           yield @body
         elsif @body.respond_to?(:read)
           read_method = @body.respond_to?(:readpartial) ? :readpartial : :read
+          buffer      = String.new
 
           begin
-            while (data = @body.send(read_method, CHUNK_SIZE))
+            while (data = @body.send(read_method, CHUNK_SIZE, buffer))
               yield data
             end
           rescue EOFError

--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -28,11 +28,11 @@ module HTTP
       # Yields chunks of content to be streamed to the request body.
       #
       # @yieldparam [String]
-      def each
+      def each(&block)
         if @body.is_a?(String)
           yield @body
         elsif @body.respond_to?(:read)
-          IO.copy_stream(@body, BlockIO.new(Proc.new))
+          IO.copy_stream(@body, BlockIO.new(block))
         elsif @body.is_a?(Enumerable)
           @body.each { |chunk| yield chunk }
         end

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -60,12 +60,11 @@ module HTTP
       end
 
       def send_request
-        headers = join_headers
         # It's important to send the request in a single write call when
         # possible in order to play nicely with Nagle's algorithm. Making
         # two writes in a row triggers a pathological case where Nagle is
         # expecting a third write that never happens.
-        data = headers
+        data = join_headers
 
         @body.each do |chunk|
           data << encode_chunk(chunk)

--- a/spec/lib/http/request/body_spec.rb
+++ b/spec/lib/http/request/body_spec.rb
@@ -88,11 +88,17 @@ RSpec.describe HTTP::Request::Body do
   end
 
   describe "#each" do
+    def chunks
+      chunks = []
+      subject.each { |chunk| chunks << chunk.dup }
+      chunks
+    end
+
     context "when body is nil" do
       let(:body) { nil }
 
       it "yields nothing" do
-        expect(subject.each.to_a).to eq []
+        expect(chunks).to eq []
       end
     end
 
@@ -100,7 +106,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { "content" }
 
       it "yields the string" do
-        expect(subject.each.to_a).to eq %w(content)
+        expect(chunks).to eq %w(content)
       end
     end
 
@@ -108,7 +114,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { FakeIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
 
       it "yields chunks of content" do
-        expect(subject.each.to_a).to eq ["a" * 16 * 1024, "b" * 10 * 1024]
+        expect(chunks).to eq ["a" * 16 * 1024, "b" * 10 * 1024]
       end
     end
 
@@ -116,7 +122,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { StringIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
 
       it "yields chunks of content" do
-        expect(subject.each.to_a).to eq ["a" * 16 * 1024, "b" * 10 * 1024]
+        expect(chunks).to eq ["a" * 16 * 1024, "b" * 10 * 1024]
       end
     end
 
@@ -124,7 +130,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { %w(bees cows) }
 
       it "yields elements" do
-        expect(subject.each.to_a).to eq %w(bees cows)
+        expect(chunks).to eq %w(bees cows)
       end
     end
   end

--- a/spec/lib/http/request/body_spec.rb
+++ b/spec/lib/http/request/body_spec.rb
@@ -88,17 +88,11 @@ RSpec.describe HTTP::Request::Body do
   end
 
   describe "#each" do
-    def chunks
-      chunks = []
-      subject.each { |chunk| chunks << chunk.dup }
-      chunks
-    end
-
     context "when body is nil" do
       let(:body) { nil }
 
       it "yields nothing" do
-        expect(chunks).to eq []
+        expect(subject.each.to_a).to eq []
       end
     end
 
@@ -106,7 +100,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { "content" }
 
       it "yields the string" do
-        expect(chunks).to eq %w(content)
+        expect(subject.each.to_a).to eq %w(content)
       end
     end
 
@@ -114,7 +108,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { FakeIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
 
       it "yields chunks of content" do
-        expect(chunks).to eq ["a" * 16 * 1024, "b" * 10 * 1024]
+        expect(subject.each.inject("", :+)).to eq "a" * 16 * 1024 + "b" * 10 * 1024
       end
     end
 
@@ -122,7 +116,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { StringIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
 
       it "yields chunks of content" do
-        expect(chunks).to eq ["a" * 16 * 1024, "b" * 10 * 1024]
+        expect(subject.each.inject("", :+)).to eq "a" * 16 * 1024 + "b" * 10 * 1024
       end
     end
 
@@ -130,7 +124,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { %w(bees cows) }
 
       it "yields elements" do
-        expect(chunks).to eq %w(bees cows)
+        expect(subject.each.to_a).to eq %w(bees cows)
       end
     end
   end

--- a/spec/lib/http/request/body_spec.rb
+++ b/spec/lib/http/request/body_spec.rb
@@ -88,11 +88,17 @@ RSpec.describe HTTP::Request::Body do
   end
 
   describe "#each" do
+    let(:chunks) do
+      chunks = []
+      subject.each { |chunk| chunks << chunk.dup }
+      chunks
+    end
+
     context "when body is nil" do
       let(:body) { nil }
 
       it "yields nothing" do
-        expect(subject.each.to_a).to eq []
+        expect(chunks).to eq []
       end
     end
 
@@ -100,7 +106,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { "content" }
 
       it "yields the string" do
-        expect(subject.each.to_a).to eq %w(content)
+        expect(chunks).to eq %w(content)
       end
     end
 
@@ -108,7 +114,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { FakeIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
 
       it "yields chunks of content" do
-        expect(subject.each.inject("", :+)).to eq "a" * 16 * 1024 + "b" * 10 * 1024
+        expect(chunks.inject("", :+)).to eq "a" * 16 * 1024 + "b" * 10 * 1024
       end
     end
 
@@ -116,7 +122,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { StringIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
 
       it "yields chunks of content" do
-        expect(subject.each.inject("", :+)).to eq "a" * 16 * 1024 + "b" * 10 * 1024
+        expect(chunks.inject("", :+)).to eq "a" * 16 * 1024 + "b" * 10 * 1024
       end
     end
 
@@ -124,7 +130,7 @@ RSpec.describe HTTP::Request::Body do
       let(:body) { %w(bees cows) }
 
       it "yields elements" do
-        expect(subject.each.to_a).to eq %w(bees cows)
+        expect(chunks).to eq %w(bees cows)
       end
     end
   end


### PR DESCRIPTION
This pull request adds two more upload improvements. First commit changes `HTTP::Request::Body` to use `IO#readpartial` if available, and second commit adds a buffer string for memory-efficient uploads; both are explained in detail in their commit descriptions.

I was hoping that, once this is merged (or rejected), we could release a new version of HTTP.rb and form_data.rb with the streaming upload feature.