### PR TITLE
Allow http_parser to decide if there is still body to read

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -211,6 +211,7 @@ module HTTP
 
       value = @socket.readpartial(size)
       if value == :eof
+        @parser << ""
         :eof
       elsif value
         @parser << value

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -50,7 +50,7 @@ module HTTP
         encoding   = opts[:encoding] || charset || Encoding::BINARY
         stream     = body_stream_for(connection, opts)
 
-        @body = Response::Body.new(stream, :encoding => encoding, :length => content_length)
+        @body = Response::Body.new(stream, :encoding => encoding)
       else
         @body = opts.fetch(:body)
       end

--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -15,13 +15,12 @@ module HTTP
       # @return [HTTP::Connection]
       attr_reader :connection
 
-      def initialize(stream, length: nil, encoding: Encoding::BINARY)
+      def initialize(stream, encoding: Encoding::BINARY)
         @stream     = stream
         @connection = stream.is_a?(Inflater) ? stream.connection : stream
         @streaming  = nil
         @contents   = nil
         @encoding   = find_encoding(encoding)
-        @length     = length || Float::INFINITY
       end
 
       # (see HTTP::Client#readpartial)
@@ -48,10 +47,7 @@ module HTTP
           @streaming  = false
           @contents   = String.new("").force_encoding(@encoding)
 
-          length = @length
-
-          while length > 0 && (chunk = @stream.readpartial)
-            length -= chunk.bytesize
+          while (chunk = @stream.readpartial)
             @contents << chunk.force_encoding(@encoding)
           end
         rescue

--- a/spec/lib/http/response/body_spec.rb
+++ b/spec/lib/http/response/body_spec.rb
@@ -3,9 +3,12 @@ RSpec.describe HTTP::Response::Body do
   let(:connection) { double(:sequence_id => 0) }
   let(:chunks)     { [String.new("Hello, "), String.new("World!")] }
 
-  before           { allow(connection).to receive(:readpartial) { chunks.shift } }
+  before do
+    allow(connection).to receive(:readpartial) { chunks.shift }
+    allow(connection).to receive(:body_completed?) { chunks.empty? }
+  end
 
-  subject(:body)   { described_class.new(connection, :encoding => Encoding::UTF_8) }
+  subject(:body) { described_class.new(connection, :encoding => Encoding::UTF_8) }
 
   it "streams bodies from responses" do
     expect(subject.to_s).to eq("Hello, World!")


### PR DESCRIPTION
It mostly fixes problem when connection which uses "Transfer-Encoding: chunked" header is closed to early, before the terminating chunk is received. In such case "http" returned partial body instead of raising error.

---

Here is how the problem can be reproduced:

Run this app (`rackup  -p 3000 -E none -s puma`):
```
$ cat config.ru 
class App
  def call(env)
    [200, {}, self]
  end

  def each
    yield 'one'
    sleep 1
    yield 'two'
    sleep 2
    yield 'three'
    sleep 3
    yield 'four'
    sleep 4
    yield 'five'
    sleep 5
    yield 'six'
  end
end

use Rack::Chunked
run App.new
```

Use irb console to make http request to the app and then kill the app (in the middle of the request):

```
2.2.3 :001 > require 'http'
 => true 
2.2.3 :002 > HTTP.get('http://localhost:3000/').body.to_s
 => "onetwo" 
```

----

All tests are passing so my fix seems to be fine, but if you think otherwise let me know and I'll try change it.