### PR TITLE
Remove http-form_data pre-release from gemspec

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.2"
 
   gem.add_runtime_dependency "http_parser.rb", "~> 0.6.0"
-  gem.add_runtime_dependency "http-form_data", ">= 2.0.0-pre2", "< 3"
+  gem.add_runtime_dependency "http-form_data", "~> 2.0"
   gem.add_runtime_dependency "http-cookie",    "~> 1.0"
   gem.add_runtime_dependency "addressable",    "~> 2.3"
 


### PR DESCRIPTION
The gemspec included the pre-release of `http-form_data` at the moment the major version wasn't out yet, and we forgot to remove it once it was released. This PR takes care of that.