### PR TITLE
Raise ConnectionError when writing to socket fails

### DIFF
--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -100,6 +100,8 @@ module HTTP
           break unless data.bytesize > length
           data = data.byteslice(length..-1)
         end
+      rescue IOError, SocketError, SystemCallError => ex
+        raise ConnectionError, "error writing to socket: #{ex}", ex.backtrace
       end
     end
   end

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -74,5 +74,15 @@ RSpec.describe HTTP::Request::Writer do
         ].join
       end
     end
+
+    context "when writing to socket raises an exception" do
+      before do
+        expect(io).to receive(:write).and_raise(Errno::EPIPE)
+      end
+
+      it "raises a ConnectionError" do
+        expect { writer.stream }.to raise_error(HTTP::ConnectionError)
+      end
+    end
   end
 end


### PR DESCRIPTION
Writing to the TCP socket can also fail with various exceptions, just like when opening or reading from it. For example, it happened to me that an `Errno::EPIPE` exceptions was raised during file upload, presumably because the server closed the connection early.

In order to be consistent with re-raising low-level exceptions as `HTTP::ConnectionError` when opening or reading from the TCP socket, we also add the same behaviour when writing to the socket.

Closes #430