### PR TITLE
Add Request::Body#source

### DIFF
--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -40,6 +40,11 @@ module HTTP
         end
       end
 
+      # Request bodies are equivalent when they have the same source.
+      def ==(other)
+        self.class == other.class && self.source == other.source # rubocop:disable Style/RedundantSelf
+      end
+
       private
 
       def validate_source_type!

--- a/spec/lib/http/request/body_spec.rb
+++ b/spec/lib/http/request/body_spec.rb
@@ -141,4 +141,33 @@ RSpec.describe HTTP::Request::Body do
       end
     end
   end
+
+  describe "#==" do
+    context "when sources are equivalent" do
+      let(:body1) { HTTP::Request::Body.new("content") }
+      let(:body2) { HTTP::Request::Body.new("content") }
+
+      it "returns true" do
+        expect(body1).to eq body2
+      end
+    end
+
+    context "when sources are not equivalent" do
+      let(:body1) { HTTP::Request::Body.new("content") }
+      let(:body2) { HTTP::Request::Body.new(nil) }
+
+      it "returns false" do
+        expect(body1).not_to eq body2
+      end
+    end
+
+    context "when objects are not of the same class" do
+      let(:body1) { HTTP::Request::Body.new("content") }
+      let(:body2) { "content" }
+
+      it "returns false" do
+        expect(body1).not_to eq body2
+      end
+    end
+  end
 end

--- a/spec/lib/http/request/body_spec.rb
+++ b/spec/lib/http/request/body_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe HTTP::Request::Body do
     end
   end
 
+  describe "#source" do
+    it "returns the original object" do
+      expect(subject.source).to eq ""
+    end
+  end
+
   describe "#size" do
     context "when body is nil" do
       let(:body) { nil }


### PR DESCRIPTION
This makes it possible to access the original body object, which [httplog](https://github.com/trusche/httplog) needs to log request bodies.

Related to #437.