### PR TITLE
Simplify setting a timeout

### DIFF
--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -3,27 +3,25 @@
 require "timeout"
 require "io/wait"
 
-require "http/timeout/per_operation"
+require "http/timeout/null"
 
 module HTTP
   module Timeout
-    class Global < PerOperation
-      attr_reader :time_left, :total_timeout
-
+    class Global < Null
       def initialize(*args)
         super
-        reset_counter
+
+        @timeout = @time_left = options.fetch(:global_timeout)
       end
 
       # To future me: Don't remove this again, past you was smarter.
       def reset_counter
-        @time_left = connect_timeout + read_timeout + write_timeout
-        @total_timeout = time_left
+        @time_left = @timeout
       end
 
       def connect(socket_class, host, port, nodelay = false)
         reset_timer
-        ::Timeout.timeout(time_left, TimeoutError) do
+        ::Timeout.timeout(@time_left, TimeoutError) do
           @socket = socket_class.open(host, port)
           @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1) if nodelay
         end
@@ -37,11 +35,11 @@ module HTTP
         begin
           @socket.connect_nonblock
         rescue IO::WaitReadable
-          IO.select([@socket], nil, nil, time_left)
+          IO.select([@socket], nil, nil, @time_left)
           log_time
           retry
         rescue IO::WaitWritable
-          IO.select(nil, [@socket], nil, time_left)
+          IO.select(nil, [@socket], nil, @time_left)
           log_time
           retry
         end
@@ -105,13 +103,13 @@ module HTTP
 
       # Wait for a socket to become readable
       def wait_readable_or_timeout
-        @socket.to_io.wait_readable(time_left)
+        @socket.to_io.wait_readable(@time_left)
         log_time
       end
 
       # Wait for a socket to become writable
       def wait_writable_or_timeout
-        @socket.to_io.wait_writable(time_left)
+        @socket.to_io.wait_writable(@time_left)
         log_time
       end
 
@@ -123,8 +121,8 @@ module HTTP
 
       def log_time
         @time_left -= (Time.now - @started)
-        if time_left <= 0
-          raise TimeoutError, "Timed out after using the allocated #{total_timeout} seconds"
+        if @time_left <= 0
+          raise TimeoutError, "Timed out after using the allocated #{@timeout} seconds"
         end
 
         reset_timer

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -49,12 +49,12 @@ RSpec.describe HTTP do
     end
 
     context "with a large request body" do
-      %w[global null per_operation].each do |timeout|
-        context "with a #{timeout} timeout" do
+      [:null, 6, {:read => 2, :write => 2, :connect => 2}].each do |timeout|
+        context "with `.timeout(#{timeout.inspect})`" do
           [16_000, 16_500, 17_000, 34_000, 68_000].each do |size|
             [0, rand(0..100), rand(100..1000)].each do |fuzzer|
               context "with a #{size} body and #{fuzzer} of fuzzing" do
-                let(:client) { HTTP.timeout(timeout, :read => 2, :write => 2, :connect => 2) }
+                let(:client) { HTTP.timeout(timeout) }
 
                 let(:characters) { ("A".."Z").to_a }
                 let(:request_body) do
@@ -299,7 +299,16 @@ RSpec.describe HTTP do
   end
 
   describe ".timeout" do
-    context "without timeout type" do
+    context "specifying a null timeout" do
+      subject(:client) { HTTP.timeout :null }
+
+      it "sets timeout_class to Null" do
+        expect(client.default_options.timeout_class).
+          to be HTTP::Timeout::Null
+      end
+    end
+
+    context "specifying per operation timeouts" do
       subject(:client) { HTTP.timeout :read => 123 }
 
       it "sets timeout_class to PerOperation" do
@@ -313,46 +322,18 @@ RSpec.describe HTTP do
       end
     end
 
-    context "with :null type" do
-      subject(:client) { HTTP.timeout :null, :read => 123 }
-
-      it "sets timeout_class to Null" do
-        expect(client.default_options.timeout_class).
-          to be HTTP::Timeout::Null
-      end
-    end
-
-    context "with :per_operation type" do
-      subject(:client) { HTTP.timeout :per_operation, :read => 123 }
-
-      it "sets timeout_class to PerOperation" do
-        expect(client.default_options.timeout_class).
-          to be HTTP::Timeout::PerOperation
-      end
-
-      it "sets given timeout options" do
-        expect(client.default_options.timeout_options).
-          to eq :read_timeout => 123
-      end
-    end
-
-    context "with :global type" do
-      subject(:client) { HTTP.timeout :global, :read => 123 }
+    context "specifying a global timeout" do
+      subject(:client) { HTTP.timeout 123 }
 
       it "sets timeout_class to Global" do
         expect(client.default_options.timeout_class).
           to be HTTP::Timeout::Global
       end
 
-      it "sets given timeout options" do
+      it "sets given timeout option" do
         expect(client.default_options.timeout_options).
-          to eq :read_timeout => 123
+          to eq :global_timeout => 123
       end
-    end
-
-    it "fails with unknown timeout type" do
-      expect { HTTP.timeout(:foobar, :read => 123) }.
-        to raise_error(ArgumentError, /foobar/)
     end
   end
 

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -249,15 +249,15 @@ RSpec.describe HTTP do
 
   describe ".basic_auth" do
     it "fails when options is not a Hash" do
-      expect { HTTP.basic_auth "[FOOBAR]" }.to raise_error
+      expect { HTTP.basic_auth "[FOOBAR]" }.to raise_error(NoMethodError)
     end
 
     it "fails when :pass is not given" do
-      expect { HTTP.basic_auth :user => "[USER]" }.to raise_error
+      expect { HTTP.basic_auth :user => "[USER]" }.to raise_error(KeyError)
     end
 
     it "fails when :user is not given" do
-      expect { HTTP.basic_auth :pass => "[PASS]" }.to raise_error
+      expect { HTTP.basic_auth :pass => "[PASS]" }.to raise_error(KeyError)
     end
 
     it "sets Authorization header with proper BasicAuth value" do


### PR DESCRIPTION
- `.timeout(<Numeric>)` sets a global timeout value.
- `.timeout(connect: x, write: y, read: z)` sets per operation timeouts.

The previous style: `.timeout(:global|:per_operation, hash_of_options)` doesn't work anymore.

fixes #444
  