### PR TITLE
Fix query string building for string with newlines

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -123,7 +123,7 @@ module HTTP
       uri = HTTP::URI.parse uri
 
       if opts.params && !opts.params.empty?
-        uri.query = [uri.query, HTTP::URI.form_encode(opts.params)].compact.join("&")
+        uri.query_values = uri.query_values(Array).to_a.concat(opts.params.to_a)
       end
 
       # Some proxies (seen on WEBRick) fail if URL has

--- a/lib/http/uri.rb
+++ b/lib/http/uri.rb
@@ -15,6 +15,7 @@ module HTTP
     def_delegators :@uri, :normalized_port, :port=
     def_delegators :@uri, :path, :normalized_path, :path=
     def_delegators :@uri, :query, :normalized_query, :query=
+    def_delegators :@uri, :query_values, :query_values=
     def_delegators :@uri, :request_uri, :request_uri=
     def_delegators :@uri, :fragment, :normalized_fragment, :fragment=
     def_delegators :@uri, :omit, :join, :normalize

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -156,6 +156,14 @@ RSpec.describe HTTP::Client do
 
       client.get("http://example.com/", :params => {:t => "1970-01-01T00:00:00Z"})
     end
+
+    it 'does not convert newlines into \r\n before encoding string values' do
+      expect(HTTP::Request).to receive(:new) do |opts|
+        expect(opts[:uri].query).to eq "foo=bar%0Abaz"
+      end
+
+      client.get("http://example.com/", :params => {:foo => "bar\nbaz"})
+    end
   end
 
   describe "passing multipart form data" do


### PR DESCRIPTION
Expose `HTTP::URI#query_values` & `HTTP::URI#query_values=` which delegate to the underlying `Addressable::URI` instead of using Addressable's `form_encode` method.

fixes #449 