### PR TITLE
Reduce memory usage when reading response body

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -35,6 +35,7 @@ module HTTP
       @pending_request      = false
       @pending_response     = false
       @failed_proxy_connect = false
+      @buffer               = "".b
 
       @parser = Response::Parser.new
 
@@ -210,7 +211,7 @@ module HTTP
     def read_more(size)
       return if @parser.finished?
 
-      value = @socket.readpartial(size)
+      value = @socket.readpartial(size, @buffer)
       if value == :eof
         @parser << ""
         :eof

--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -46,8 +46,8 @@ module HTTP
       end
 
       # Read from the socket
-      def readpartial(size)
-        perform_io { read_nonblock(size) }
+      def readpartial(size, buffer = nil)
+        perform_io { read_nonblock(size, buffer) }
       end
 
       # Write to the socket
@@ -60,16 +60,16 @@ module HTTP
       private
 
       if RUBY_VERSION < "2.1.0"
-        def read_nonblock(size)
-          @socket.read_nonblock(size)
+        def read_nonblock(size, buffer = nil)
+          @socket.read_nonblock(size, buffer)
         end
 
         def write_nonblock(data)
           @socket.write_nonblock(data)
         end
       else
-        def read_nonblock(size)
-          @socket.read_nonblock(size, :exception => false)
+        def read_nonblock(size, buffer = nil)
+          @socket.read_nonblock(size, buffer, :exception => false)
         end
 
         def write_nonblock(data)

--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -41,8 +41,8 @@ module HTTP
       end
 
       # Read from the socket
-      def readpartial(size)
-        @socket.readpartial(size)
+      def readpartial(size, buffer = nil)
+        @socket.readpartial(size, buffer)
       rescue EOFError
         :eof
       end

--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -37,9 +37,9 @@ module HTTP
       # NIO with exceptions
       if RUBY_VERSION < "2.1.0"
         # Read data from the socket
-        def readpartial(size)
+        def readpartial(size, buffer = nil)
           rescue_readable do
-            @socket.read_nonblock(size)
+            @socket.read_nonblock(size, buffer)
           end
         rescue EOFError
           :eof
@@ -57,10 +57,10 @@ module HTTP
       # NIO without exceptions
       else
         # Read data from the socket
-        def readpartial(size)
+        def readpartial(size, buffer = nil)
           timeout = false
           loop do
-            result = @socket.read_nonblock(size, :exception => false)
+            result = @socket.read_nonblock(size, buffer, :exception => false)
 
             return :eof   if result.nil?
             return result if result != :wait_readable


### PR DESCRIPTION
Currently for each chunk read from the socket a new string is being allocated. This is not necessary, because we're feeding that string object into the HTTP parser and never using it again.

So we initialize a buffer string and pass it in when reading chunks. This will make each chunk be read into the same buffer object, no new string will be allocated in that operation.

When profiling download of a 18MB file, before this change there was 48MB of strings being allocated, and after this change it's about 18MB. This is **more than 50%** reduction in memory allocation.