### PR TITLE
Deallocate temporary strings in Response::Body#to_s

### DIFF
--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -50,6 +50,7 @@ module HTTP
 
           while (chunk = @stream.readpartial)
             @contents << chunk.force_encoding(@encoding)
+            chunk.clear # deallocate string
           end
         rescue
           @contents = nil


### PR DESCRIPTION
From Eric Wong (Ruby & Unicorn committer) in "[String memory use reduction techniques](https://ruby-talk.trydiscourse.com/t/psa-string-memory-use-reduction-techniques/74477)"

> String#clear exists since Ruby 1.9.1 and immediately releases memory allocated from malloc(3). I use this to reduce memory pressure and improve locality when working with large buffers.

An example of how such clearing of used string objects reduced memory usage in `open-uri`: https://bugs.ruby-lang.org/issues/14320

I tested the memory usage using `MemoryProfiler`, and it did show **50% reduction** in allocated memory:

```rb
require "http"
require "memory_profiler"

MemoryProfiler.report do
  HTTP.get("https://upload.wikimedia.org/wikipedia/commons/3/36/Hopetoun_falls.jpg").to_s
end.pretty_print

# BEFORE: Total allocated: 6234558 bytes (1720 objects)
# AFTER:  Total allocated: 3278647 bytes (1720 objects)
```

Now, I'm aware that having `String#clear` statements adds a bit of clutter, but I think it's a good tradeoff when dealing with relatively large strings like chunks of a response body.