### PR TITLE
Removing unreacheable code in HTTP::Features::AutoDeflate

### DIFF
--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -22,8 +22,6 @@ module HTTP
           GzippedBody.new(body)
         when "deflate"
           DeflatedBody.new(body)
-        else
-          raise ArgumentError, "Unsupported deflate method: #{method}"
         end
       end
 


### PR DESCRIPTION
On aa7c688 `HTTP::Features::AutoDeflate` got a major refactoring, delegating most of the work to their own classes (`GzippedBody` & `DeflatedBody`), but a branch preventing a wrong value passed to #deflated_body (`headers` params) was left behind.

Currently the removed code will never be executed because the values of the property `method` are enforced on the `initializer` (accepting only gzip & deflated):

https://github.com/httprb/http/blob/b3ac5564eeb3efac936e2e919329a48755c61ad3/lib/http/features/auto_deflate.rb#L11-L17