### PR TITLE
Fix #readpartial not respecting max length argument

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -86,7 +86,7 @@ module HTTP
     def readpartial(size = BUFFER_SIZE)
       return unless @pending_response
 
-      chunk = @parser.get_chunk(size)
+      chunk = @parser.read(size)
       return chunk if chunk
 
       finished = (read_more(size) == :eof) || @parser.finished?

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -86,9 +86,11 @@ module HTTP
     def readpartial(size = BUFFER_SIZE)
       return unless @pending_response
 
+      chunk = @parser.get_chunk(size)
+      return chunk if chunk
+
       finished = (read_more(size) == :eof) || @parser.finished?
       chunk    = @parser.chunk
-
       finish_response if finished
 
       chunk.to_s

--- a/lib/http/response/parser.rb
+++ b/lib/http/response/parser.rb
@@ -43,7 +43,7 @@ module HTTP
         end
       end
 
-      def get_chunk(size)
+      def read(size)
         return if @chunk.nil?
 
         if @chunk.bytesize <= size

--- a/lib/http/response/parser.rb
+++ b/lib/http/response/parser.rb
@@ -3,7 +3,7 @@
 module HTTP
   class Response
     class Parser
-      attr_reader :headers
+      attr_reader :headers, :chunk
 
       def initialize
         @parser = HTTP::Parser.new(self)
@@ -43,9 +43,17 @@ module HTTP
         end
       end
 
-      def chunk
-        chunk  = @chunk
-        @chunk = nil
+      def get_chunk(size)
+        return if @chunk.nil?
+
+        if @chunk.bytesize <= size
+          chunk  = @chunk
+          @chunk = nil
+        else
+          chunk = @chunk.byteslice(0, size)
+          @chunk[0, size] = ""
+        end
+
         chunk
       end
 


### PR DESCRIPTION
Fixes https://github.com/httprb/http/issues/384.

```rb
response = HTTP.get('http://www.rubydoc.info/github/httprb/http')
5.times { puts response.body.readpartial(10).length }
# 10
# 10
# 10
# 10
# 10
```

I didn't find an easy way to write specs for this, because everything is stubbed :stuck_out_tongue: