### PR TITLE
Simplify HTTP::Connection#read_headers!

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -97,13 +97,9 @@ module HTTP
     # Reads data from socket up until headers are loaded
     # @return [void]
     def read_headers!
-      loop do
-        if read_more(BUFFER_SIZE) == :eof
-          raise ConnectionError, "couldn't read response headers" unless @parser.headers?
-          break
-        elsif @parser.headers?
-          break
-        end
+      until @parser.headers?
+        result = read_more(BUFFER_SIZE)
+        raise ConnectionError, "couldn't read response headers" if result == :eof
       end
 
       set_keep_alive


### PR DESCRIPTION
This simplifies the implementation of `HTTP::Connection#read_headers!`, the behaviour should be preserved.