### PR TITLE
Extract HTTP::Client#build_request method

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -70,10 +70,19 @@ module HTTP
     end
 
     # Make an HTTP request with the given verb
+    # @param verb
     # @param uri
     # @option options [Hash]
     def request(verb, uri, options = {}) # rubocop:disable Style/OptionHash
       branch(options).request verb, uri
+    end
+
+    # Prepare an HTTP request with the given verb
+    # @param verb
+    # @param uri
+    # @option options [Hash]
+    def prepare_request(verb, uri, options = {}) # rubocop:disable Style/OptionHash
+      branch(options).prepare_request verb, uri
     end
 
     # @overload timeout(options = {})

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -81,8 +81,8 @@ module HTTP
     # @param verb
     # @param uri
     # @option options [Hash]
-    def prepare_request(verb, uri, options = {}) # rubocop:disable Style/OptionHash
-      branch(options).prepare_request verb, uri
+    def build_request(verb, uri, options = {}) # rubocop:disable Style/OptionHash
+      branch(options).build_request verb, uri
     end
 
     # @overload timeout(options = {})

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -26,7 +26,7 @@ module HTTP
     # Make an HTTP request
     def request(verb, uri, opts = {}) # rubocop:disable Style/OptionHash
       opts = @default_options.merge(opts)
-      req = prepare_request(verb, uri, opts)
+      req = build_request(verb, uri, opts)
       res = perform(req, opts)
       return res unless opts.follow
 
@@ -36,7 +36,7 @@ module HTTP
     end
 
     # Prepare an HTTP request
-    def prepare_request(verb, uri, opts = {}) # rubocop:disable Style/OptionHash
+    def build_request(verb, uri, opts = {}) # rubocop:disable Style/OptionHash
       opts    = @default_options.merge(opts)
       uri     = make_request_uri(uri, opts)
       headers = make_request_headers(opts)


### PR DESCRIPTION
It would sometimes be handy to have a public method that returns a request object so that we can modify it and/or pass around and then use `perform` on it. 
Please take a look and if you find the idea is OK I will add specs etc.