### PR TITLE
Fix HTTP::Request#headline to allow two leading slashes in path

### DIFF
--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -154,7 +154,7 @@ module HTTP
         if using_proxy? && !uri.https?
           uri.omit(:fragment)
         else
-          uri.omit(:scheme, :authority, :fragment)
+          uri.request_uri
         end
 
       "#{verb.to_s.upcase} #{request_uri} HTTP/#{version}"

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe HTTP do
       end
     end
 
+    context "with two leading slashes in path" do
+      it "is allowed" do
+        expect { HTTP.get "#{dummy.endpoint}//" }.not_to raise_error
+      end
+    end
+
     context "with headers" do
       it "is easy" do
         response = HTTP.accept("application/json").get dummy.endpoint


### PR DESCRIPTION
HTTP.get doesn't allow to make requests to urls with two leading slashes (e.g. `https://google.com//`).

See previous discussion at #389.

Steps to reproduce
===

```ruby
HTTP.get("https://google.com//")
#Addressable::URI::InvalidURIError: Cannot have a path with two leading slashes without anauthority set: '//'
```

Now it's possible to use such urls.