### PR TITLE
Rewind IO-alike request body after it was consumed.

### DIFF
--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -35,6 +35,7 @@ module HTTP
           yield @source
         elsif @source.respond_to?(:read)
           IO.copy_stream(@source, ProcIO.new(block))
+          @source.rewind if @source.respond_to?(:rewind)
         elsif @source.is_a?(Enumerable)
           @source.each(&block)
         end

--- a/spec/lib/http/request/body_spec.rb
+++ b/spec/lib/http/request/body_spec.rb
@@ -126,10 +126,26 @@ RSpec.describe HTTP::Request::Body do
     end
 
     context "when body is an Enumerable IO" do
-      let(:body) { StringIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
+      let(:data) { "a" * 16 * 1024 + "b" * 10 * 1024 }
+      let(:body) { StringIO.new data }
 
       it "yields chunks of content" do
-        expect(chunks.inject("", :+)).to eq "a" * 16 * 1024 + "b" * 10 * 1024
+        expect(chunks.inject("", :+)).to eq data
+      end
+
+      it "allows to enumerate multiple times" do
+        results = []
+
+        2.times do
+          result = ""
+          subject.each { |chunk| result += chunk }
+          results << result
+        end
+
+        aggregate_failures do
+          expect(results.count).to eq 2
+          expect(results).to all eq data
+        end
       end
     end
 


### PR DESCRIPTION
Webmock triggers `body.each` twice upon inital request recording:

1. to perform request
2. to record request data into webmock request registry

But even without WebMock, generally Body#each must be replayable IMO.