### PR TITLE
operation-specific timeout subclasses

### DIFF
--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -19,6 +19,15 @@ module HTTP
   # Generic Timeout error
   class TimeoutError < Error; end
 
+  # A timeout error that occurred on connect
+  class ConnectTimeoutError < TimeoutError; end
+
+  # A timeout error that occurred while reading the response
+  class ReadTimeoutError < TimeoutError; end
+
+  # A timeout error that occurred while writing the request
+  class WriteTimeoutError < TimeoutError; end
+
   # Header value is of unexpected format (similar to Net::HTTPHeaderSyntaxError)
   class HeaderError < Error; end
 end


### PR DESCRIPTION
Use separate subclasses for each type of operation that can timeout: connect, write, and read.

I also tried to add more test coverage to handle the different timeout scenarios. There are two main issues I ran into:

* Testing a connect timeout of 0 just never works locally. This could easily be done using an external server (i.e. hitting `api.github.com` as the tests do elsewhere) but that wouldn't work cleanly with the way these shared examples are used for SSL vs non-SSL. That was a bigger change than I wanted to make here.
* The only way I could reliably trigger a write timeout of 0 was with a sizable request body. However, if the write timeout is increased in this scenario, I'm seeing broken pipe connection errors. Would love to hear ideas on how to make this work.

Fixes #470.