### PR TITLE
Accept output buffer in Response::Body#readpartial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env: JRUBY_OPTS="$JRUBY_OPTS --debug"
 
 rvm:
   # Include JRuby first because it takes the longest
-  - jruby-9.1.16.0
+  - jruby-9.2.0.0
   - 2.3
   - 2.4
   - 2.5

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -86,6 +86,7 @@ module HTTP
     def readpartial(size = BUFFER_SIZE)
       return unless @pending_response
 
+      # return chunk of body that was retrieved when reading response headers
       chunk = @parser.read(size)
       return chunk if chunk
 
@@ -93,7 +94,7 @@ module HTTP
       chunk    = @parser.read(size)
       finish_response if finished
 
-      chunk.to_s
+      chunk
     end
 
     # Reads data from socket up until headers are loaded


### PR DESCRIPTION
This makes it possible to use a `HTTP::Response::Body` object as a source argument in `IO.copy_stream`, allowing easy streaming. It also allows it to be used in the request body for another request (as `HTTP::Request::Body::Writer` uses `IO.copy_stream`), should anyone want that.

```rb
response = HTTP.get("http://example.com/download")
IO.copy_stream(response.body, destination)
```

Since `IO.copy_stream` uses an output buffer, it makes retrieving the response body much more memory efficient, because we're able to deallocate retrieved chunks. I tested with a 50MB response body, and streaming with `HTTP::Response::Body#each` allocated about 52MB of strings, whereas the `IO.copy_stream` version allocated only 3MB.

`IO.copy_stream` requires `#readpartial` to have `IO#readpartial` semantics, which among others includes raising and `EOFError` when end of file was reached. Since `IO.copy_stream` always uses an output buffer, the exception is raised only when output buffer is specified.