### PR TITLE
Handle early responses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,11 @@ Layout/SpaceAroundOperators:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
+## Lint ########################################################################
+
+Lint/HandleExceptions:
+  Enabled: false
+
 ## Metrics #####################################################################
 
 Metrics/AbcSize:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,11 +13,6 @@ Layout/SpaceAroundOperators:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-## Lint ########################################################################
-
-Lint/HandleExceptions:
-  Enabled: false
-
 ## Metrics #####################################################################
 
 Metrics/AbcSize:

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -100,6 +100,8 @@ module HTTP
           break unless data.bytesize > length
           data = data.byteslice(length..-1)
         end
+      rescue Errno::EPIPE
+        # server doesn't need any more data
       rescue IOError, SocketError, SystemCallError => ex
         raise ConnectionError, "error writing to socket: #{ex}", ex.backtrace
       end

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -76,6 +76,8 @@ module HTTP
         write(data) unless data.empty?
 
         write(CHUNKED_END) if chunked?
+      rescue Errno::EPIPE
+        # server doesn't need any more data
       end
 
       # Returns the chunk encoded for to the specified "Transfer-Encoding" header.
@@ -101,7 +103,7 @@ module HTTP
           data = data.byteslice(length..-1)
         end
       rescue Errno::EPIPE
-        # server doesn't need any more data
+        raise # re-raise Errno::EPIPE
       rescue IOError, SocketError, SystemCallError => ex
         raise ConnectionError, "error writing to socket: #{ex}", ex.backtrace
       end

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -75,9 +75,19 @@ RSpec.describe HTTP::Request::Writer do
       end
     end
 
-    context "when writing to socket raises an exception" do
+    context "when server won't accept any more data" do
       before do
         expect(io).to receive(:write).and_raise(Errno::EPIPE)
+      end
+
+      it "aborts silently" do
+        writer.stream
+      end
+    end
+
+    context "when writing to socket raises an exception" do
+      before do
+        expect(io).to receive(:write).and_raise(Errno::ECONNRESET)
       end
 
       it "raises a ConnectionError" do


### PR DESCRIPTION
HTTP servers typically wait until the whole request body has been received before sending the response. However, some servers might send out a response early, before they've read the whole request body. For example, they might detect the request headers were invalid, and they want to tell that to the client immediately.

For example, sending a large request to http://google.com will return an early `400 Bad Request` response. In this case http.rb will raise an `Errno::EPIPE` exception (wrapped in a `HTTP::ConnectionError`), because it tried to write to the socket but it couldn't because the server closed its end. However, the server still returned a valid response, so it's not really erroneous behaviour (e.g. curl doesn't print any errors in the same situations).

  ```rb
  # Before
  HTTP.get("http://google.com", body: "a" * 1*1024*1024)
  #~> Errno::EPIPE

  # After
  HTTP.get("http://google.com", body: "a" * 1*1024*1024)
  #=> #<HTTP::Response 400 Bad Request ...>
  ```

This commit changes `Request::Writer` to stop writing when an `Errno::EPIPE` exception occurred.