### PR TITLE
Apply basic authentication from URI

### DIFF
--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -252,6 +252,17 @@ RSpec.describe HTTP do
     end
   end
 
+  context "with URL including basic auth" do
+    it "applies basic auth" do
+      uri = HTTP::URI.parse(dummy.endpoint)
+      uri.user     = "john"
+      uri.password = "secret"
+
+      headers = JSON.parse(HTTP.get("#{uri}/headers").to_s)
+      expect(headers["Authorization"]).to match(%r{^Basic [A-Za-z0-9+/]+=*$})
+    end
+  end
+
   describe ".persistent" do
     let(:host) { "https://api.github.com" }
 

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # encoding: UTF-8
 
+require "json"
+
 class DummyServer < WEBrick::HTTPServer
   # rubocop:disable Metrics/ClassLength
   class Servlet < WEBrick::HTTPServlet::AbstractServlet
@@ -125,6 +127,16 @@ class DummyServer < WEBrick::HTTPServer
     head "/" do |_req, res|
       res.status          = 200
       res["Content-Type"] = "text/html"
+    end
+
+    get "/headers" do |_req, res|
+      headers = _req.header.inject({}) do |hash, (name, values)|
+        header_name = name.split("-").map(&:capitalize).join("-")
+        hash.merge! header_name => values.first
+      end
+
+      res.status = 200
+      res.body = JSON.dump(headers)
     end
 
     get "/bytes" do |_req, res|


### PR DESCRIPTION
URIs can have basic authentication defined in them, for example:

```
https://janko:secret@example.com
```

Currently username and password in URIs are ignored. This change modifies HTTP::Client to automatically detect these options and applies basic authentication.

Closes #476