### PR TITLE
Refactor AutoInflate/Deflate into generic features

### DIFF
--- a/lib/http/feature.rb
+++ b/lib/http/feature.rb
@@ -5,5 +5,13 @@ module HTTP
     def initialize(opts = {}) # rubocop:disable Style/OptionHash
       @opts = opts
     end
+
+    def wrap_request(request)
+      request
+    end
+
+    def wrap_response(response)
+      response
+    end
   end
 end

--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -16,6 +16,19 @@ module HTTP
         raise Error, "Only gzip and deflate methods are supported" unless %w[gzip deflate].include?(@method)
       end
 
+      def wrap_request(request)
+        return request unless method
+
+        Request.new(
+          :version => request.version,
+          :verb => request.verb,
+          :uri => request.uri,
+          :headers => request.headers,
+          :proxy => request.proxy,
+          :body => deflated_body(request.body)
+        )
+      end
+
       def deflated_body(body)
         case method
         when "gzip"
@@ -34,6 +47,11 @@ module HTTP
         def size
           compress_all! unless @compressed
           @compressed.size
+        end
+
+        def read(*a)
+          compress_all! unless @compressed
+          @compressed.read(*a)
         end
 
         def each(&block)

--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -3,6 +3,8 @@
 require "zlib"
 require "tempfile"
 
+require "http/request/body"
+
 module HTTP
   module Features
     class AutoDeflate < Feature
@@ -38,20 +40,15 @@ module HTTP
         end
       end
 
-      class CompressedBody
-        def initialize(body)
-          @body       = body
+      class CompressedBody < HTTP::Request::Body
+        def initialize(uncompressed_body)
+          @body       = uncompressed_body
           @compressed = nil
         end
 
         def size
           compress_all! unless @compressed
           @compressed.size
-        end
-
-        def read(*a)
-          compress_all! unless @compressed
-          @compressed.read(*a)
         end
 
         def each(&block)

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -87,7 +87,6 @@ module HTTP
 
       @proxy   = opts[:proxy] || {}
       @body    = Request::Body.new(opts[:body])
-      @deflate = opts[:auto_deflate]
       @version = opts[:version] || "1.1"
       @headers = HTTP::Headers.coerce(opts[:headers] || {})
 
@@ -106,7 +105,6 @@ module HTTP
         :headers      => headers,
         :proxy        => proxy,
         :body         => body.source,
-        :auto_deflate => @deflate,
         :version      => version
       )
     end
@@ -114,7 +112,6 @@ module HTTP
     # Stream the request to a socket
     def stream(socket)
       include_proxy_headers if using_proxy? && !@uri.https?
-      body = @deflate ? @deflate.deflated_body(self.body) : self.body
       Request::Writer.new(socket, body, headers, headline).stream
     end
 

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -86,7 +86,7 @@ module HTTP
       raise(UnsupportedSchemeError, "unknown scheme: #{scheme}") unless SCHEMES.include?(@scheme)
 
       @proxy   = opts[:proxy] || {}
-      @body    = Request::Body.new(opts[:body])
+      @body    = (body = opts[:body]).is_a?(Request::Body) ? body : Request::Body.new(body)
       @version = opts[:version] || "1.1"
       @headers = HTTP::Headers.coerce(opts[:headers] || {})
 

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -20,6 +20,9 @@ module HTTP
     # @return [Status]
     attr_reader :status
 
+    # @return [String]
+    attr_reader :version
+
     # @return [Body]
     attr_reader :body
 
@@ -46,14 +49,13 @@ module HTTP
       @headers       = HTTP::Headers.coerce(opts[:headers] || {})
       @proxy_headers = HTTP::Headers.coerce(opts[:proxy_headers] || {})
 
-      if opts.include?(:connection)
+      if opts.include?(:body)
+        @body = opts.fetch(:body)
+      else
         connection = opts.fetch(:connection)
         encoding   = opts[:encoding] || charset || Encoding::BINARY
-        stream     = body_stream_for(connection, opts)
 
-        @body = Response::Body.new(stream, :encoding => encoding)
-      else
-        @body = opts.fetch(:body)
+        @body = Response::Body.new(connection, :encoding => encoding)
       end
     end
 
@@ -159,16 +161,6 @@ module HTTP
     # Inspect a response
     def inspect
       "#<#{self.class}/#{@version} #{code} #{reason} #{headers.to_h.inspect}>"
-    end
-
-    private
-
-    def body_stream_for(connection, opts)
-      if opts[:auto_inflate]
-        opts[:auto_inflate].stream_for(connection, self)
-      else
-        connection
-      end
     end
   end
 end

--- a/spec/lib/http/features/auto_inflate_spec.rb
+++ b/spec/lib/http/features/auto_inflate_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe HTTP::Features::AutoInflate do
-  subject { HTTP::Features::AutoInflate.new }
+  subject(:feature) { HTTP::Features::AutoInflate.new }
   let(:connection) { double }
   let(:headers) { {} }
   let(:response) do
@@ -13,56 +13,52 @@ RSpec.describe HTTP::Features::AutoInflate do
     )
   end
 
-  describe "stream_for" do
+  describe "wrap_response" do
+    subject(:result) { feature.wrap_response(response) }
+
     context "when there is no Content-Encoding header" do
-      it "returns connection" do
-        stream = subject.stream_for(connection, response)
-        expect(stream).to eq(connection)
+      it "returns original request" do
+        expect(result).to be response
       end
     end
 
     context "for identity Content-Encoding header" do
-      let(:headers) { {:content_encoding => "not-supported"} }
+      let(:headers) { {:content_encoding => "identity"} }
 
-      it "returns connection" do
-        stream = subject.stream_for(connection, response)
-        expect(stream).to eq(connection)
+      it "returns original request" do
+        expect(result).to be response
       end
     end
 
     context "for unknown Content-Encoding header" do
       let(:headers) { {:content_encoding => "not-supported"} }
 
-      it "returns connection" do
-        stream = subject.stream_for(connection, response)
-        expect(stream).to eq(connection)
+      it "returns original request" do
+        expect(result).to be response
       end
     end
 
     context "for deflate Content-Encoding header" do
       let(:headers) { {:content_encoding => "deflate"} }
 
-      it "returns HTTP::Response::Inflater instance - connection wrapper" do
-        stream = subject.stream_for(connection, response)
-        expect(stream).to be_instance_of HTTP::Response::Inflater
+      it "returns a HTTP::Response wrapping the inflated response body" do
+        expect(result.body).to be_instance_of HTTP::Response::Body
       end
     end
 
     context "for gzip Content-Encoding header" do
       let(:headers) { {:content_encoding => "gzip"} }
 
-      it "returns HTTP::Response::Inflater instance - connection wrapper" do
-        stream = subject.stream_for(connection, response)
-        expect(stream).to be_instance_of HTTP::Response::Inflater
+      it "returns a HTTP::Response wrapping the inflated response body" do
+        expect(result.body).to be_instance_of HTTP::Response::Body
       end
     end
 
     context "for x-gzip Content-Encoding header" do
       let(:headers) { {:content_encoding => "x-gzip"} }
 
-      it "returns HTTP::Response::Inflater instance - connection wrapper" do
-        stream = subject.stream_for(connection, response)
-        expect(stream).to be_instance_of HTTP::Response::Inflater
+      it "returns a HTTP::Response wrapping the inflated response body" do
+        expect(result.body).to be_instance_of HTTP::Response::Body
       end
     end
   end


### PR DESCRIPTION
This makes `HTTP::Client`, `Request` and `Response` unaware of the implementation details behind inflating and deflating stream bodies. Instead, the client iterates over all enabled features on request and response, calling `#wrap_request` or `#wrap_response`, which is expected to return the Request or Response as-is if nothing should be done, or returns a new Request or Response object after having done whatever transformation the feature requires.

Related to #478 (and all the issues linked therein), this also provides a clean way to implement more features, like logging/instrumentation, caching, etc... In fact, several existing http.rb features could be probably be refactored into this style and clean up the codebase (proxy, json parsing, cookies, redirects...)

This pattern also avoids callbacks and chained-middleware (but it is a little similar), two things I know @tarcieri wasn't a fan of. Using `#inject` to iterate over the enabled features means that the default behavior of just returning the original object is a no-op, and doesn't allocate any additional objects.

```
 >> o = Object.new
=> #<Object:0x000055e0c6e69888>
>> [1, 2, 3, 4].inject(o) { |obj, i| obj }
=> #<Object:0x000055e0c6e69888>
```

I'd also like to nuke the "available features" whitelist in place of some sort of registry, or some other flexible way to add additional features to the list, but I wanted to get feedback on this approach first.
