### PR TITLE
RFC: Allow passing server as an option to allow DRYing multiple interactions with same endpoint and parameterising API integrations by environment

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -153,6 +153,10 @@ module HTTP
       p_client.close if p_client
     end
 
+    def to(host)
+      branch default_options.with_origin(host)
+    end
+
     # Make a request through an HTTP proxy
     # @param [Array] proxy
     # @raise [Request::Error] if HTTP proxy is invalid

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -127,8 +127,8 @@ module HTTP
     def make_request_uri(uri, opts)
       uri = uri.to_s
 
-      if default_options.persistent? && uri !~ HTTP_OR_HTTPS_RE
-        uri = "#{default_options.persistent}#{uri}"
+      if default_options.origin && uri !~ HTTP_OR_HTTPS_RE
+        uri = "#{default_options.origin}#{uri}"
       end
 
       uri = HTTP::URI.parse uri

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -141,10 +141,16 @@ module HTTP
         end
     end
 
+    def_option :origin, :reader_only => true
+
+    def origin=(value)
+      @origin = value ? HTTP::URI.parse(value).origin : nil
+    end
+
     def_option :persistent, :reader_only => true
 
     def persistent=(value)
-      @persistent = value ? HTTP::URI.parse(value).origin : nil
+      @persistent = self.origin = value
     end
 
     def persistent?

--- a/spec/lib/http/options/merge_spec.rb
+++ b/spec/lib/http/options/merge_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe HTTP::Options, "merge" do
       :form               => {:bar => "bar"},
       :body               => "body-bar",
       :json               => {:bar => "bar"},
+      :origin             => "https://www.googe.com",
       :persistent         => "https://www.googe.com",
       :keep_alive_timeout => 10,
       :ssl                => {:foo => "bar"},

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -283,6 +283,18 @@ RSpec.describe HTTP do
     end
   end
 
+  describe ".to" do
+    subject(:client) { HTTP.to dummy.endpoint }
+
+    it { is_expected.to be_an HTTP::Client }
+    it { is_expected.to_not be_persistent }
+
+    it "accepts just a path as uri" do
+      response = client.post("/echo-body", body: "a body")
+      expect(response.to_s).to eq("a body")
+    end
+  end
+
   describe ".timeout" do
     context "specifying a null timeout" do
       subject(:client) { HTTP.timeout :null }


### PR DESCRIPTION
I've wanted this each time I've reached for HTTP so thought I'd propose this as an addition. The use-case here is when using HTTP as an internal client for something like an API client which may connect to different endpoints. Currently, the only (non-persistent) way to provide the hostname to connect to is when building the actual request, which can often mean having to pass more configuration deeper into these wrapper classes.

As a matter of abstraction, there are instances where it is simpler to allow a class to use only relative paths to resources and be passed a fully configured HTTP client to execute them.

This leverages the existing mechanism for building URIs as persisted
connections does but is a matter of convenient, not connection sharing.

I suspect this will need further work, in particular to ensure nothing is broken with persistent connections and to explore the desired error messages or alternate behaviour when attempting to bind to a host but also persistently connect to another.

A contrived example to show usage (in my actual use-case, persistent connections can't be used in 100% of cases, even though they could in this example):

``` ruby
http = HTTP.
  to('https://github.com').
  accept(:json).
  auth('Bearer abc123')

# executes .get('/repos') or whatever
RepositoryArchiver.new(client: http).archive_if { |repo| ... }
```