### PR TITLE
Base URI

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -245,6 +245,12 @@ module HTTP
       branch default_options.with_features(features)
     end
 
+    # Join base uri to all request uris
+    # @param uri
+    def uri(uri)
+      branch default_options.with_uri(uri)
+    end
+
     private
 
     # :nodoc:

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -128,6 +128,8 @@ module HTTP
     def make_request_uri(uri, opts)
       uri = uri.to_s
 
+      uri = default_options.uri.join(uri).to_s if default_options.uri
+
       if default_options.persistent? && uri !~ HTTP_OR_HTTPS_RE
         uri = "#{default_options.persistent}#{uri}"
       end

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -64,7 +64,8 @@ module HTTP
         :headers            => {},
         :cookies            => {},
         :encoding           => nil,
-        :features           => {}
+        :features           => {},
+        :uri                => nil
       }
 
       opts_w_defaults = defaults.merge(options)
@@ -139,14 +140,20 @@ module HTTP
         end
     end
 
-    def_option :persistent, :reader_only => true
+    def_option :uri, :reader_only => true
 
-    def persistent=(value)
-      @persistent = value ? HTTP::URI.parse(value).origin : nil
+    def uri=(value)
+      @uri = value ? HTTP::URI.parse(value) : nil
     end
+
+    def_option :persistent, :reader_only => true
 
     def persistent?
       !persistent.nil?
+    end
+
+    def persistent=(value)
+      @persistent = value ? HTTP::URI.parse(value).origin : nil
     end
 
     def merge(other)

--- a/spec/lib/http/options/merge_spec.rb
+++ b/spec/lib/http/options/merge_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe HTTP::Options, "merge" do
       :json      => {:foo => "foo"},
       :headers   => {:accept => "json", :foo => "foo"},
       :proxy     => {},
-      :features  => {}
+      :features  => {},
+      :uri       => HTTP::URI.parse("https://foo.com")
     )
 
     bar = HTTP::Options.new(
@@ -39,7 +40,8 @@ RSpec.describe HTTP::Options, "merge" do
       :headers            => {:accept => "xml", :bar => "bar"},
       :timeout_options    => {:foo => :bar},
       :ssl        => {:foo => "bar"},
-      :proxy      => {:proxy_address => "127.0.0.1", :proxy_port => 8080}
+      :proxy      => {:proxy_address => "127.0.0.1", :proxy_port => 8080},
+      :uri        => HTTP::URI.parse("https://bar.com")
     )
 
     expect(foo.merge(bar).to_hash).to eq(
@@ -62,7 +64,8 @@ RSpec.describe HTTP::Options, "merge" do
       :ssl_context        => nil,
       :cookies            => {},
       :encoding           => nil,
-      :features           => {}
+      :features           => {},
+      :uri                => HTTP::URI.parse("https://bar.com")
     )
   end
 end

--- a/spec/lib/http/options/new_spec.rb
+++ b/spec/lib/http/options/new_spec.rb
@@ -26,5 +26,10 @@ RSpec.describe HTTP::Options, "new" do
       opts = HTTP::Options.new(:form => {:foo => 42})
       expect(opts.form).to eq(:foo => 42)
     end
+
+    it "coerces :uri correctly" do
+      opts = HTTP::Options.new(:uri => "https://example.com")
+      expect(opts.uri).to eq(HTTP::URI.parse("https://example.com"))
+    end
   end
 end

--- a/spec/lib/http/options/uri_spec.rb
+++ b/spec/lib/http/options/uri_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe HTTP::Options, "uri" do
+  let(:opts) { HTTP::Options.new }
+
+  it "defaults to nil" do
+    expect(opts.uri).to be(nil)
+  end
+
+  it "may be specified with with_uri" do
+    opts2 = opts.with_uri("https://example.com")
+    expect(opts.uri).to be(nil)
+    expect(opts2.uri).to eq(HTTP::URI.parse("https://example.com"))
+  end
+end

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -252,6 +252,22 @@ RSpec.describe HTTP do
     end
   end
 
+  describe ".uri" do
+    let(:base_uri) { "#{dummy.endpoint}/base/" }
+
+    subject(:client) { HTTP.uri(base_uri) }
+
+    it "uses the uri as a base during requests" do
+      response = client.get("foo")
+      expect(response.status.ok?)
+      expect(response.body.to_s).to eq("Foo")
+
+      response = client.get("bar")
+      expect(response.status.ok?)
+      expect(response.body.to_s).to eq("Bar")
+    end
+  end
+
   describe ".persistent" do
     let(:host) { "https://api.github.com" }
 

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -170,5 +170,15 @@ class DummyServer < WEBrick::HTTPServer
                    "#{req.body}-raw"
                  end
     end
+
+    get "/base/foo" do |_req, res|
+      res.status = 200
+      res.body = "Foo"
+    end
+
+    get "/base/bar" do |_req, res|
+      res.status = 200
+      res.body = "Bar"
+    end
   end
 end

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -27,6 +27,8 @@ class DummyServer < WEBrick::HTTPServer
           handler = self.class.handlers["#{method}:\#{req.path}"]
           return instance_exec(req, res, &handler) if handler
           not_found(req, res)
+        rescue
+          puts "Error in \#{self.class.name}: \#{$!}", *$!.backtrace
         end
       RUBY
     end

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -26,7 +26,7 @@ class DummyServer < WEBrick::HTTPServer
         def do_#{method.upcase}(req, res)
           handler = self.class.handlers["#{method}:\#{req.path}"]
           return instance_exec(req, res, &handler) if handler
-          not_found
+          not_found(req, res)
         end
       RUBY
     end
@@ -67,7 +67,7 @@ class DummyServer < WEBrick::HTTPServer
     end
 
     get "/params" do |req, res|
-      next not_found unless "foo=bar" == req.query_string
+      next not_found(req, res) unless "foo=bar" == req.query_string
 
       res.status = 200
       res.body   = "Params!"
@@ -76,7 +76,7 @@ class DummyServer < WEBrick::HTTPServer
     get "/multiple-params" do |req, res|
       params = CGI.parse req.query_string
 
-      next not_found unless {"foo" => ["bar"], "baz" => ["quux"]} == params
+      next not_found(req, res) unless {"foo" => ["bar"], "baz" => ["quux"]} == params
 
       res.status = 200
       res.body   = "More Params!"


### PR DESCRIPTION
Prototype of #512: Allow baking a base URI into an HTTP::Client. Super useful for creating an API client then requesting on paths alone, and making endpoints configurable:

```ruby
client = HTTP.uri("https://api.stripe.com/v1/").auth(...)
client.get("charges")
client.post("customers", json: {...})
# ...
```

Persistent gets part way there, but only allows specifying the origin excluding path prefixes, and requires opting in to persistent connections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/httprb/http/513)
<!-- Reviewable:end -->
