### PR TITLE
Respect default_options for HTTP::Chainable#request and HTTP::Chainable#build_request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: bundler
 before_install:
   - gem update --system
   - gem --version
-  - gem install bundler --no-rdoc --no-ri
+  - gem install bundler
   - bundle --version
 
 install: bundle install --without development doc

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -70,19 +70,15 @@ module HTTP
     end
 
     # Make an HTTP request with the given verb
-    # @param verb
-    # @param uri
-    # @option options [Hash]
-    def request(verb, uri, options = {}) # rubocop:disable Style/OptionHash
-      branch(options).request verb, uri
+    # @param (see Client#request)
+    def request(*args)
+      branch(default_options).request(*args)
     end
 
     # Prepare an HTTP request with the given verb
-    # @param verb
-    # @param uri
-    # @option options [Hash]
-    def build_request(verb, uri, options = {}) # rubocop:disable Style/OptionHash
-      branch(options).build_request verb, uri
+    # @param (see Client#build_request)
+    def build_request(*args)
+      branch(default_options).build_request(*args)
     end
 
     # @overload timeout(options = {})


### PR DESCRIPTION
Currently, if default_options are set, they are respected for methods such as #via or #timeout but not with a simple request.

Let me know if this would make sense, or if the current implementation is intentional!

cc @zanker HI ZANKER :)