### PR TITLE
Skip auto-deflate when there is no body

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -160,14 +160,6 @@ module HTTP
         headers[Headers::COOKIE] = cookies
       end
 
-      if (auto_deflate = opts.feature(:auto_deflate))
-        # We need to delete Content-Length header. It will be set automatically
-        # by HTTP::Request::Writer
-        headers.delete(Headers::CONTENT_LENGTH)
-
-        headers[Headers::CONTENT_ENCODING] = auto_deflate.method
-      end
-
       headers
     end
 

--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -20,6 +20,11 @@ module HTTP
 
       def wrap_request(request)
         return request unless method
+        return request if request.body.size.zero?
+
+        # We need to delete Content-Length header. It will be set automatically by HTTP::Request::Writer
+        request.headers.delete(Headers::CONTENT_LENGTH)
+        request.headers[Headers::CONTENT_ENCODING] = method
 
         Request.new(
           :version => request.version,

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe HTTP::Client do
 
     context "when :auto_deflate was specified" do
       let(:headers) { {"Content-Length" => "12"} }
-      let(:client)  { described_class.new :headers => headers, :features => {:auto_deflate => {}} }
+      let(:client)  { described_class.new :headers => headers, :features => {:auto_deflate => {}}, :body => "foo" }
 
       it "deletes Content-Length header" do
         expect(client).to receive(:perform) do |req, _|
@@ -250,6 +250,18 @@ RSpec.describe HTTP::Client do
         end
 
         client.request(:get, "http://example.com/")
+      end
+
+      context "and there is no body" do
+        let(:client) { described_class.new :headers => headers, :features => {:auto_deflate => {}} }
+
+        it "doesn't set Content-Encoding header" do
+          expect(client).to receive(:perform) do |req, _|
+            expect(req.headers).not_to include "Content-Encoding"
+          end
+
+          client.request(:get, "http://example.com/")
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #521

Also move auto-deflate related code from `http/client.rb` to `http/features/auto_deflate.rb` which seems to be move appropriate place.