### PR TITLE
Add metadata links for rubygems

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -33,4 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "addressable",    "~> 2.3"
 
   gem.add_development_dependency "bundler", "~> 2.0"
+
+  gem.metadata["source_code_uri"] = "https://github.com/httprb/http"
+  gem.metadata["changelog_uri"] = "https://github.com/httprb/http/blob/master/CHANGES.md"
 end

--- a/http.gemspec
+++ b/http.gemspec
@@ -34,6 +34,10 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler", "~> 2.0"
 
-  gem.metadata["source_code_uri"] = "https://github.com/httprb/http"
-  gem.metadata["changelog_uri"] = "https://github.com/httprb/http/blob/master/CHANGES.md"
+  gem.metadata = {
+    "source_code_uri" => "https://github.com/httprb/http",
+    "wiki_uri"        => "https://github.com/httprb/http/wiki",
+    "bug_tracker_uri" => "https://github.com/httprb/http/issues",
+    "changelog_uri"   => "https://github.com/httprb/http/blob/v#{HTTP::VERSION}/CHANGES.md"
+  }
 end


### PR DESCRIPTION
Add metadata for the source and changelog. These create direct links on rubygems, as well as help with automated management of gem upgrades.