### PR TITLE
Avoid YARD "UnknownTag" warning

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -168,7 +168,7 @@ module HTTP
     alias through via
 
     # Make client follow redirects.
-    # @param opts
+    # @param options
     # @return [HTTP::Client]
     # @see Redirector#initialize
     def follow(options = {}) # rubocop:disable Style/OptionHash


### PR DESCRIPTION
This PR fixes this YARD warning:

```
lib/http/chainable.rb:171: [UnknownParam] @param tag has unknown parameter name: opts
```