### PR TITLE
Access the HTTP::Request from the HTTP::Response

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -82,7 +82,6 @@ module HTTP
         :proxy_headers => @connection.proxy_response_headers,
         :connection    => @connection,
         :encoding      => options.encoding,
-        :uri           => req.uri,
         :request       => req
       )
 

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -82,7 +82,8 @@ module HTTP
         :proxy_headers => @connection.proxy_response_headers,
         :connection    => @connection,
         :encoding      => options.encoding,
-        :uri           => req.uri
+        :uri           => req.uri,
+        :request       => req
       )
 
       res = options.features.inject(res) do |response, (_name, feature)|

--- a/lib/http/features/auto_inflate.rb
+++ b/lib/http/features/auto_inflate.rb
@@ -17,7 +17,8 @@ module HTTP
           :headers       => response.headers,
           :proxy_headers => response.proxy_headers,
           :connection    => response.connection,
-          :body          => stream_for(response.connection)
+          :body          => stream_for(response.connection),
+          :request       => response.request
         }
 
         options[:uri] = response.uri if response.uri

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -29,6 +29,9 @@ module HTTP
     # @return [URI, nil]
     attr_reader :uri
 
+    # @return [Request]
+    attr_reader :request
+
     # @return [Hash]
     attr_reader :proxy_headers
 
@@ -48,6 +51,7 @@ module HTTP
       @status        = HTTP::Response::Status.new(opts.fetch(:status))
       @headers       = HTTP::Headers.coerce(opts[:headers] || {})
       @proxy_headers = HTTP::Headers.coerce(opts[:proxy_headers] || {})
+      @request       = opts.fetch(:request)
 
       if opts.include?(:body)
         @body = opts.fetch(:body)

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -47,11 +47,11 @@ module HTTP
     # @option opts [String] :uri
     def initialize(opts)
       @version       = opts.fetch(:version)
-      @uri           = HTTP::URI.parse(opts.fetch(:uri)) if opts.include? :uri
+      @request       = opts.fetch(:request)
+      @uri           = HTTP::URI.parse(opts[:uri] || @request.uri)
       @status        = HTTP::Response::Status.new(opts.fetch(:status))
       @headers       = HTTP::Headers.coerce(opts[:headers] || {})
       @proxy_headers = HTTP::Headers.coerce(opts[:proxy_headers] || {})
-      @request       = opts.fetch(:request)
 
       if opts.include?(:body)
         @body = opts.fetch(:body)

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe HTTP::Client do
       :status  => status,
       :version => "1.1",
       :headers => {"Location" => location},
-      :body    => ""
+      :body    => "",
+      :request => HTTP::Request.new(:verb => :get, :uri => "http://example.com")
     )
   end
 
@@ -39,7 +40,8 @@ RSpec.describe HTTP::Client do
     HTTP::Response.new(
       :status  => status,
       :version => "1.1",
-      :body    => body
+      :body    => body,
+      :request => HTTP::Request.new(:verb => :get, :uri => "http://example.com")
     )
   end
 
@@ -314,6 +316,14 @@ RSpec.describe HTTP::Client do
     it "calls finish_response once body was fully flushed" do
       expect_any_instance_of(HTTP::Connection).to receive(:finish_response).and_call_original
       client.get(dummy.endpoint).to_s
+    end
+
+    it "provides access to the Request from the Response" do
+      unique_value = "20190424"
+      response = client.headers("X-Value" => unique_value).get(dummy.endpoint)
+
+      expect(response.request).to be_a(HTTP::Request)
+      expect(response.request.headers["X-Value"]).to eq(unique_value)
     end
 
     context "with HEAD request" do

--- a/spec/lib/http/features/auto_inflate_spec.rb
+++ b/spec/lib/http/features/auto_inflate_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe HTTP::Features::AutoInflate do
       :version    => "1.1",
       :status     => 200,
       :headers    => headers,
-      :connection => connection
+      :connection => connection,
+      :request    => HTTP::Request.new(:verb => :get, :uri => "http://example.com")
     )
   end
 
@@ -73,7 +74,8 @@ RSpec.describe HTTP::Features::AutoInflate do
           :status     => 200,
           :headers    => {:content_encoding => "gzip"},
           :connection => connection,
-          :uri        => "https://example.com"
+          :uri        => "https://example.com",
+          :request    => HTTP::Request.new(:verb => :get, :uri => "https://example.com")
         )
       end
 

--- a/spec/lib/http/features/instrumentation_spec.rb
+++ b/spec/lib/http/features/instrumentation_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe HTTP::Features::Instrumentation do
         :uri     => "https://example.com",
         :status  => 200,
         :headers => {:content_type => "application/json"},
-        :body    => '{"success": true}'
+        :body    => '{"success": true}',
+        :request => HTTP::Request.new(:verb => :get, :uri => "https://example.com")
       )
     end
 

--- a/spec/lib/http/features/logging_spec.rb
+++ b/spec/lib/http/features/logging_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe HTTP::Features::Logging do
         :uri     => "https://example.com",
         :status  => 200,
         :headers => {:content_type => "application/json"},
-        :body    => '{"success": true}'
+        :body    => '{"success": true}',
+        :request => HTTP::Request.new(:verb => :get, :uri => "https://example.com")
       )
     end
 

--- a/spec/lib/http/redirector_spec.rb
+++ b/spec/lib/http/redirector_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe HTTP::Redirector do
       :status  => status,
       :version => "1.1",
       :headers => headers,
-      :body    => body
+      :body    => body,
+      :request => HTTP::Request.new(:verb => :get, :uri => "http://example.com")
     )
   end
 

--- a/spec/lib/http/response_spec.rb
+++ b/spec/lib/http/response_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe HTTP::Response do
       :version => "1.1",
       :headers => headers,
       :body    => body,
-      :uri     => uri
+      :uri     => uri,
+      :request => HTTP::Request.new(:verb => :get, :uri => "http://example.com")
     )
   end
 
@@ -152,7 +153,8 @@ RSpec.describe HTTP::Response do
       HTTP::Response.new(
         :version    => "1.1",
         :status     => 200,
-        :connection => connection
+        :connection => connection,
+        :request    => HTTP::Request.new(:verb => :get, :uri => "http://example.com")
       )
     end
 


### PR DESCRIPTION
This fixes https://github.com/httprb/http/issues/463

This will greatly enhance the abilities of pluggable `Features` by
being able to reference the Request that initiated a Response. It will make it easy to solves issues like https://github.com/httprb/http/issues/545.

I wasn't very happy with all the changes to the specs to put a "fake" Request, but felt it was pretty important that the Request object be mandatory when creating a Response. If we left it optional, it might be too easy to create a new code path (like the `auto_inflate` code) that doesn't properly set the initiating Request. Open to suggestions.