### PR TITLE
RuboCop upgrade 0.68 (latest)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   TargetRubyVersion: 2.3
   DisplayCopNames: true
@@ -12,6 +14,11 @@ Layout/SpaceAroundOperators:
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+
+Layout/AlignHash:
+  Enabled: false
+  EnforcedColonStyle: table
+  EnforcedHashRocketStyle: table
 
 ## Metrics #####################################################################
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,10 @@ AllCops:
 
 ## Layout ######################################################################
 
+Layout/AlignHash:
+  EnforcedColonStyle: table
+  EnforcedHashRocketStyle: table
+
 Layout/DotPosition:
   EnforcedStyle: trailing
 
@@ -14,11 +18,6 @@ Layout/SpaceAroundOperators:
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
-
-Layout/AlignHash:
-  Enabled: false
-  EnforcedColonStyle: table
-  EnforcedHashRocketStyle: table
 
 ## Metrics #####################################################################
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,8 @@ group :test do
   gem "rspec", "~> 3.0"
   gem "rspec-its"
 
-  gem "rubocop", "= 0.59.2"
+  gem "rubocop", "= 0.68.1"
+  gem "rubocop-performance"
 
   gem "yardstick"
 end

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -106,7 +106,7 @@ module HTTP
       end
 
       branch default_options.merge(
-        :timeout_class => klass,
+        :timeout_class   => klass,
         :timeout_options => options
       )
     end

--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -16,7 +16,7 @@ module HTTP
     extend Forwardable
     include Chainable
 
-    HTTP_OR_HTTPS_RE = %r{^https?://}i
+    HTTP_OR_HTTPS_RE = %r{^https?://}i.freeze
 
     def initialize(default_options = {})
       @default_options = HTTP::Options.new(default_options)

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -45,8 +45,8 @@ module HTTP
       send_proxy_connect_request(req)
       start_tls(req, options)
       reset_timer
-    rescue IOError, SocketError, SystemCallError => ex
-      raise ConnectionError, "failed to connect: #{ex}", ex.backtrace
+    rescue IOError, SocketError, SystemCallError => e
+      raise ConnectionError, "failed to connect: #{e}", e.backtrace
     end
 
     # @see (HTTP::Response::Parser#status_code)
@@ -216,8 +216,8 @@ module HTTP
       elsif value
         @parser << value
       end
-    rescue IOError, SocketError, SystemCallError => ex
-      raise ConnectionError, "error reading from socket: #{ex}", ex.backtrace
+    rescue IOError, SocketError, SystemCallError => e
+      raise ConnectionError, "error reading from socket: #{e}", e.backtrace
     end
   end
 end

--- a/lib/http/content_type.rb
+++ b/lib/http/content_type.rb
@@ -2,8 +2,8 @@
 
 module HTTP
   ContentType = Struct.new(:mime_type, :charset) do
-    MIME_TYPE_RE = %r{^([^/]+/[^;]+)(?:$|;)}
-    CHARSET_RE   = /;\s*charset=([^;]+)/i
+    MIME_TYPE_RE = %r{^([^/]+/[^;]+)(?:$|;)}.freeze
+    CHARSET_RE   = /;\s*charset=([^;]+)/i.freeze
 
     class << self
       # Parse string and return ContentType struct

--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -27,12 +27,12 @@ module HTTP
         request.headers[Headers::CONTENT_ENCODING] = method
 
         Request.new(
-          :version => request.version,
-          :verb => request.verb,
-          :uri => request.uri,
-          :headers => request.headers,
-          :proxy => request.proxy,
-          :body => deflated_body(request.body),
+          :version        => request.version,
+          :verb           => request.verb,
+          :uri            => request.uri,
+          :headers        => request.headers,
+          :proxy          => request.proxy,
+          :body           => deflated_body(request.body),
           :uri_normalizer => request.uri_normalizer
         )
       end

--- a/lib/http/features/auto_inflate.rb
+++ b/lib/http/features/auto_inflate.rb
@@ -12,12 +12,12 @@ module HTTP
         return response unless supported_encoding?(response)
 
         options = {
-          :status => response.status,
-          :version => response.version,
-          :headers => response.headers,
+          :status        => response.status,
+          :version       => response.version,
+          :headers       => response.headers,
           :proxy_headers => response.proxy_headers,
-          :connection => response.connection,
-          :body => stream_for(response.connection)
+          :connection    => response.connection,
+          :body          => stream_for(response.connection)
         }
 
         options[:uri] = response.uri if response.uri

--- a/lib/http/headers.rb
+++ b/lib/http/headers.rb
@@ -13,11 +13,11 @@ module HTTP
     include Enumerable
 
     # Matches HTTP header names when in "Canonical-Http-Format"
-    CANONICAL_NAME_RE = /\A[A-Z][a-z]*(?:-[A-Z][a-z]*)*\z/
+    CANONICAL_NAME_RE = /\A[A-Z][a-z]*(?:-[A-Z][a-z]*)*\z/.freeze
 
     # Matches valid header field name according to RFC.
     # @see http://tools.ietf.org/html/rfc7230#section-3.2
-    COMPLIANT_NAME_RE = /\A[A-Za-z0-9!#\$%&'*+\-.^_`|~]+\z/
+    COMPLIANT_NAME_RE = /\A[A-Za-z0-9!#\$%&'*+\-.^_`|~]+\z/.freeze
 
     # Class constructor.
     def initialize

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -54,10 +54,10 @@ module HTTP
 
     # Default ports of supported schemes
     PORTS = {
-      :http   => 80,
-      :https  => 443,
-      :ws     => 80,
-      :wss    => 443
+      :http  => 80,
+      :https => 443,
+      :ws    => 80,
+      :wss   => 443
     }.freeze
 
     # Method is given as a lowercase symbol e.g. :get, :post
@@ -168,8 +168,8 @@ module HTTP
     # Headers to send with proxy connect request
     def proxy_connect_headers
       connect_headers = HTTP::Headers.coerce(
-        Headers::HOST        => headers[Headers::HOST],
-        Headers::USER_AGENT  => headers[Headers::USER_AGENT]
+        Headers::HOST       => headers[Headers::HOST],
+        Headers::USER_AGENT => headers[Headers::USER_AGENT]
       )
 
       connect_headers[Headers::PROXY_AUTHORIZATION] = proxy_authorization_header if using_authenticated_proxy?

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -113,8 +113,8 @@ module HTTP
         end
       rescue Errno::EPIPE
         raise
-      rescue IOError, SocketError, SystemCallError => ex
-        raise ConnectionError, "error writing to socket: #{ex}", ex.backtrace
+      rescue IOError, SocketError, SystemCallError => e
+        raise ConnectionError, "error writing to socket: #{e}", e.backtrace
       end
     end
   end

--- a/lib/http/uri.rb
+++ b/lib/http/uri.rb
@@ -31,11 +31,11 @@ module HTTP
       uri = HTTP::URI.parse uri
 
       HTTP::URI.new(
-        :scheme     => uri.normalized_scheme,
-        :authority  => uri.normalized_authority,
-        :path       => uri.normalized_path,
-        :query      => uri.query,
-        :fragment   => uri.normalized_fragment
+        :scheme    => uri.normalized_scheme,
+        :authority => uri.normalized_authority,
+        :path      => uri.normalized_path,
+        :query     => uri.query,
+        :fragment  => uri.normalized_fragment
       )
     end
 

--- a/spec/lib/http/connection_spec.rb
+++ b/spec/lib/http/connection_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe HTTP::Connection do
   let(:req) do
     HTTP::Request.new(
-      :verb     => :get,
-      :uri      => "http://example.com/",
-      :headers  => {}
+      :verb    => :get,
+      :uri     => "http://example.com/",
+      :headers => {}
     )
   end
   let(:socket) { double(:connect => nil) }

--- a/spec/lib/http/features/instrumentation_spec.rb
+++ b/spec/lib/http/features/instrumentation_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe HTTP::Features::Instrumentation do
   describe "logging the request" do
     let(:request) do
       HTTP::Request.new(
-        :verb => :post,
-        :uri => "https://example.com/",
+        :verb    => :post,
+        :uri     => "https://example.com/",
         :headers => {:accept => "application/json"},
-        :body => '{"hello": "world!"}'
+        :body    => '{"hello": "world!"}'
       )
     end
 
@@ -25,10 +25,10 @@ RSpec.describe HTTP::Features::Instrumentation do
     let(:response) do
       HTTP::Response.new(
         :version => "1.1",
-        :uri => "https://example.com",
-        :status => 200,
+        :uri     => "https://example.com",
+        :status  => 200,
         :headers => {:content_type => "application/json"},
-        :body => '{"success": true}'
+        :body    => '{"success": true}'
       )
     end
 

--- a/spec/lib/http/features/logging_spec.rb
+++ b/spec/lib/http/features/logging_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe HTTP::Features::Logging do
   describe "logging the request" do
     let(:request) do
       HTTP::Request.new(
-        :verb     => :post,
-        :uri      => "https://example.com/",
-        :headers  => {:accept => "application/json"},
-        :body     => '{"hello": "world!"}'
+        :verb    => :post,
+        :uri     => "https://example.com/",
+        :headers => {:accept => "application/json"},
+        :body    => '{"hello": "world!"}'
       )
     end
 

--- a/spec/lib/http/options/merge_spec.rb
+++ b/spec/lib/http/options/merge_spec.rb
@@ -18,28 +18,28 @@ RSpec.describe HTTP::Options, "merge" do
     # FIXME: yuck :(
 
     foo = HTTP::Options.new(
-      :response  => :body,
-      :params    => {:baz => "bar"},
-      :form      => {:foo => "foo"},
-      :body      => "body-foo",
-      :json      => {:foo => "foo"},
-      :headers   => {:accept => "json", :foo => "foo"},
-      :proxy     => {},
-      :features  => {}
+      :response => :body,
+      :params   => {:baz => "bar"},
+      :form     => {:foo => "foo"},
+      :body     => "body-foo",
+      :json     => {:foo => "foo"},
+      :headers  => {:accept => "json", :foo => "foo"},
+      :proxy    => {},
+      :features => {}
     )
 
     bar = HTTP::Options.new(
-      :response   => :parsed_body,
-      :persistent => "https://www.googe.com",
-      :params     => {:plop => "plip"},
-      :form       => {:bar => "bar"},
-      :body       => "body-bar",
-      :json       => {:bar => "bar"},
+      :response           => :parsed_body,
+      :persistent         => "https://www.googe.com",
+      :params             => {:plop => "plip"},
+      :form               => {:bar => "bar"},
+      :body               => "body-bar",
+      :json               => {:bar => "bar"},
       :keep_alive_timeout => 10,
       :headers            => {:accept => "xml", :bar => "bar"},
       :timeout_options    => {:foo => :bar},
-      :ssl        => {:foo => "bar"},
-      :proxy      => {:proxy_address => "127.0.0.1", :proxy_port => 8080}
+      :ssl                => {:foo => "bar"},
+      :proxy              => {:proxy_address => "127.0.0.1", :proxy_port => 8080}
     )
 
     expect(foo.merge(bar).to_hash).to eq(

--- a/spec/lib/http/request_spec.rb
+++ b/spec/lib/http/request_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe HTTP::Request do
 
   subject :request do
     HTTP::Request.new(
-      :verb     => :get,
-      :uri      => request_uri,
-      :headers  => headers,
-      :proxy    => proxy
+      :verb    => :get,
+      :uri     => request_uri,
+      :headers => headers,
+      :proxy   => proxy
     )
   end
 

--- a/spec/support/dummy_server.rb
+++ b/spec/support/dummy_server.rb
@@ -13,15 +13,15 @@ class DummyServer < WEBrick::HTTPServer
   include ServerConfig
 
   CONFIG = {
-    :BindAddress  => "127.0.0.1",
-    :Port         => 0,
-    :AccessLog    => BlackHole,
-    :Logger       => BlackHole
+    :BindAddress => "127.0.0.1",
+    :Port        => 0,
+    :AccessLog   => BlackHole,
+    :Logger      => BlackHole
   }.freeze
 
   SSL_CONFIG = CONFIG.merge(
-    :SSLEnable            => true,
-    :SSLStartImmediately  => true
+    :SSLEnable           => true,
+    :SSLStartImmediately => true
   ).freeze
 
   def initialize(options = {}) # rubocop:disable Style/OptionHash

--- a/spec/support/http_handling_shared.rb
+++ b/spec/support/http_handling_shared.rb
@@ -14,11 +14,11 @@ RSpec.shared_context "HTTP handling" do
 
     let(:options) do
       {
-        :timeout_class => HTTP::Timeout::PerOperation,
+        :timeout_class   => HTTP::Timeout::PerOperation,
         :timeout_options => {
           :connect_timeout => conn_timeout,
-          :read_timeout => read_timeout,
-          :write_timeout => write_timeout
+          :read_timeout    => read_timeout,
+          :write_timeout   => write_timeout
         }
       }
     end
@@ -62,7 +62,7 @@ RSpec.shared_context "HTTP handling" do
   context "with a global timeout" do
     let(:options) do
       {
-        :timeout_class => HTTP::Timeout::Global,
+        :timeout_class   => HTTP::Timeout::Global,
         :timeout_options => {
           :global_timeout => global_timeout
         }

--- a/spec/support/ssl_helper.rb
+++ b/spec/support/ssl_helper.rb
@@ -83,8 +83,8 @@ module SSLHelper
 
     def client_params
       {
-        :key => client_cert.key,
-        :cert => client_cert.cert,
+        :key     => client_cert.key,
+        :cert    => client_cert.cert,
         :ca_file => ca.file
       }
     end


### PR DESCRIPTION
In #548 I upgraded RuboCop by about 10 versions. In this PR I'm following up to upgrade to the latest version of RuboCop. All the changes in this PR are a result of the auto-correct flags so I didn't edit any code manually.

There are two specific items that I want to call out in this PR:
- First is that `rubocop-performance` is now its own gem that can be found here https://github.com/rubocop-hq/rubocop-performance. I suspect that we still want the performance cops to keep this project as performant as possible. Therefore I pulled the gem in and required the performance cops to keep them running. I tested to ensure that we are in fact still running performance cops.
- For Layout/AlignHash I had to make a call on which style to prefer. I personally like the table formatting, but I'm happy to change it to a different format based on what the maintainers want. The documentation for the three format options are here https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/AlignHash. I like `table` and then `key` and then I think `separator is clearly the weirdest and worst.