### PR TITLE
Allow Features to handle connection errors

### DIFF
--- a/lib/http/feature.rb
+++ b/lib/http/feature.rb
@@ -13,6 +13,8 @@ module HTTP
     def wrap_response(response)
       response
     end
+
+    def on_error(request, error); end
   end
 end
 


### PR DESCRIPTION
This addresses https://github.com/httprb/http/issues/547

It allows a Feature to implement an on_error handler so that it has a chance to react to Requests that never get a Response.