### PR TITLE
Remove unnecessary files from gemspec for smaller binary

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -18,11 +18,14 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/httprb/http"
   gem.licenses      = ["MIT"]
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
-  gem.files         = Dir["lib/**/*.rb"] +
-                      %w[http.gemspec README.md CHANGES.md LICENSE.txt]
+  Dir.chdir(__dir__) do
+    git_files = `git ls-files -z`.split("\x0")
 
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+    gem.files = git_files.grep(%r{^lib/}) +
+                %w[http.gemspec README.md CHANGES.md LICENSE.txt]
+    gem.test_files = git_files.grep(%r{^spec/})
+  end
+
   gem.name          = "http"
   gem.require_paths = ["lib"]
   gem.version       = HTTP::VERSION

--- a/http.gemspec
+++ b/http.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |gem|
   gem.licenses      = ["MIT"]
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
-  gem.files         = `git ls-files`.split("\n")
+  gem.files         = Dir["lib/**/*.rb"] +
+                      %w[http.gemspec README.md CHANGES.md LICENSE.txt]
+
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "http"
   gem.require_paths = ["lib"]


### PR DESCRIPTION
Hi! This PR reduces the file size of the gem binary from 76K to 62K by removing all those files from the gem that are only required for development and testing. Those are not really necessary in the packaged gem. I've left in README, CHANGES and LICENSE just in case - it can help for quick inspections via `bundle open` or `gem open` IMO. 

Please feel free to ignore this PR if the dev files were included intentionally, I just assume they weren't.