### PR TITLE
Improve error message when body size of a request is unknown

### DIFF
--- a/lib/http/request/body.rb
+++ b/lib/http/request/body.rb
@@ -24,7 +24,7 @@ module HTTP
         elsif @source.nil?
           0
         else
-          raise RequestError, "cannot determine size of body: #{@source.inspect}"
+          raise RequestError, "cannot determine size of body: #{@source.inspect}, please set body size with `Content-Length` header explicitly"
         end
       end
 


### PR DESCRIPTION
Hello!
Recently I tried to send an Enumerable object as a body for a request:

```ruby
http.put(url, body: enumerable_instance)
```

This is a valid body according to the code: https://github.com/httprb/http/blob/master/lib/http/request/body.rb#L76

```ruby
def validate_source_type!
  return if @source.is_a?(String)
  return if @source.respond_to?(:read)
  return if @source.is_a?(Enumerable)
  return if @source.nil?

  raise RequestError, "body of wrong type: #{@source.class}"
end
```

But the request failed with the exception `cannot determine size of body: ...`

Indeed, although `Enumerable` is a valid option for body, there is no corresponding case in `#size` function: https://github.com/httprb/http/blob/master/lib/http/request/body.rb#L17

```ruby
def size
  if @source.is_a?(String)
    @source.bytesize
  elsif @source.respond_to?(:read)
    raise RequestError, "IO object must respond to #size" unless @source.respond_to?(:size)

    @source.size
  elsif @source.nil?
    0 
  else
    raise RequestError, "cannot determine size of body: #{@source.inspect}"
  end
end
```
It seemed a bit vague for me and took some time to figure out that in this case one should set `Content-Length` header explicitly so that `Body#size` is not called: https://github.com/httprb/http/blob/master/lib/http/request/writer.rb#L50

```ruby
def add_body_type_headers
  return if @headers[Headers::CONTENT_LENGTH] || chunked?

  @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.size}"
end
```

It seemed for me that it would be useful to have some hint on it in the error message.