### PR TITLE
Use Request#uri in Response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,11 @@
   Fix HTTP parser.
   ([@ixti], [@fxposter])
 
+* [#546](https://github.com/httprb/http/pull/546)
+  **BREAKING CHANGE**
+  Provide initiating `HTTP::Request` object on `HTTP::Response`.
+  ([@joshuaflanagan])
+
 
 ## 4.1.1 (2019-03-12)
 
@@ -793,3 +798,4 @@ end
 [@RickCSong]: https://github.com/RickCSong
 [@fxposter]: https://github.com/fxposter
 [@mamoonraja]: https://github.com/mamoonraja
+[@joshuaflanagan]: https://github.com/joshuaflanagan

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -7,7 +7,6 @@ require "http/content_type"
 require "http/mime_type"
 require "http/response/status"
 require "http/response/inflater"
-require "http/uri"
 require "http/cookie_jar"
 require "time"
 
@@ -26,9 +25,6 @@ module HTTP
     # @return [Body]
     attr_reader :body
 
-    # @return [URI, nil]
-    attr_reader :uri
-
     # @return [Request]
     attr_reader :request
 
@@ -44,11 +40,10 @@ module HTTP
     # @option opts [HTTP::Connection] :connection
     # @option opts [String] :encoding Encoding to use when reading body
     # @option opts [String] :body
-    # @option opts [String] :uri
+    # @option opts [HTTP::Request] request
     def initialize(opts)
       @version       = opts.fetch(:version)
       @request       = opts.fetch(:request)
-      @uri           = HTTP::URI.parse(opts[:uri] || @request.uri)
       @status        = HTTP::Response::Status.new(opts.fetch(:status))
       @headers       = HTTP::Headers.coerce(opts[:headers] || {})
       @proxy_headers = HTTP::Headers.coerce(opts[:proxy_headers] || {})
@@ -65,24 +60,28 @@ module HTTP
 
     # @!method reason
     #   @return (see HTTP::Response::Status#reason)
-    def_delegator :status, :reason
+    def_delegator :@status, :reason
 
     # @!method code
     #   @return (see HTTP::Response::Status#code)
-    def_delegator :status, :code
+    def_delegator :@status, :code
 
     # @!method to_s
     #   (see HTTP::Response::Body#to_s)
-    def_delegator :body, :to_s
+    def_delegator :@body, :to_s
     alias to_str to_s
 
     # @!method readpartial
     #   (see HTTP::Response::Body#readpartial)
-    def_delegator :body, :readpartial
+    def_delegator :@body, :readpartial
 
     # @!method connection
     #   (see HTTP::Response::Body#connection)
-    def_delegator :body, :connection
+    def_delegator :@body, :connection
+
+    # @!method uri
+    #   @return (see HTTP::Request#uri)
+    def_delegator :@request, :uri
 
     # Returns an Array ala Rack: `[status, headers, body]`
     #


### PR DESCRIPTION
Response initialize requires Request object now, making uri parsing absolutely redundant. And as it's a breaking change anyway - we should get rid of `:uri` option completely.

NOTE: We need to update WebMock's adapter to reflect this change prior releasing v5.0.0