### PR TITLE
Preserve header casing as specified

### DIFF
--- a/spec/lib/http/connection_spec.rb
+++ b/spec/lib/http/connection_spec.rb
@@ -20,14 +20,17 @@ RSpec.describe HTTP::Connection do
         <<-RESPONSE.gsub(/^\s*\| */, "").gsub(/\n/, "\r\n")
         | HTTP/1.1 200 OK
         | Content-Type: text
+        | foo_bar: 123
         |
         RESPONSE
       end
     end
 
-    it "reads data in parts" do
+    it "populates headers collection, preserving casing" do
       connection.read_headers!
-      expect(connection.headers).to eq("Content-Type" => "text")
+      expect(connection.headers).to eq("Content-Type" => "text", "foo_bar" => "123")
+      expect(connection.headers["Foo-Bar"]).to eq("123")
+      expect(connection.headers["foo_bar"]).to eq("123")
     end
   end
 

--- a/spec/lib/http/headers_spec.rb
+++ b/spec/lib/http/headers_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe HTTP::Headers do
       expect(headers["Accept"]).to eq "application/json"
     end
 
-    it "normalizes header name" do
+    it "allows retrieval via normalized header name" do
       headers.set :content_type, "application/json"
       expect(headers["Content-Type"]).to eq "application/json"
     end
@@ -54,7 +54,7 @@ RSpec.describe HTTP::Headers do
       expect(headers["Accept"]).to eq "application/json"
     end
 
-    it "normalizes header name" do
+    it "allows retrieval via normalized header name" do
       headers[:content_type] = "application/json"
       expect(headers["Content-Type"]).to eq "application/json"
     end
@@ -80,7 +80,7 @@ RSpec.describe HTTP::Headers do
       expect(headers["Content-Type"]).to be_nil
     end
 
-    it "normalizes header name" do
+    it "removes header that matches normalized version of specified name" do
       headers.delete :content_type
       expect(headers["Content-Type"]).to be_nil
     end
@@ -104,13 +104,13 @@ RSpec.describe HTTP::Headers do
       expect(headers["Accept"]).to eq "application/json"
     end
 
-    it "normalizes header name" do
+    it "allows retrieval via normalized header name" do
       headers.add :content_type, "application/json"
       expect(headers["Content-Type"]).to eq "application/json"
     end
 
     it "appends new value if header exists" do
-      headers.add :set_cookie, "hoo=ray"
+      headers.add "Set-Cookie", "hoo=ray"
       headers.add :set_cookie, "woo=hoo"
       expect(headers["Set-Cookie"]).to eq %w[hoo=ray woo=hoo]
     end
@@ -135,6 +135,11 @@ RSpec.describe HTTP::Headers do
 
     it "fails with invalid header value" do
       expect { headers.add "foo", "bar\nEvil-Header: evil-value" }.
+        to raise_error HTTP::HeaderError
+    end
+
+    it "fails when header name is not a String or Symbol" do
+      expect { headers.add 2, "foo" }.
         to raise_error HTTP::HeaderError
     end
   end
@@ -314,6 +319,17 @@ RSpec.describe HTTP::Headers do
       )
     end
 
+    it "yields header keys specified as symbols in normalized form" do
+      keys = headers.each.map(&:first)
+      expect(keys).to eq(["Set-Cookie", "Content-Type", "Set-Cookie"])
+    end
+
+    it "yields headers specified as strings without conversion" do
+      headers.add "X_kEy", "value"
+      keys = headers.each.map(&:first)
+      expect(keys).to eq(["Set-Cookie", "Content-Type", "Set-Cookie", "X_kEy"])
+    end
+
     it "returns self instance if block given" do
       expect(headers.each { |*| }).to be headers
     end
@@ -490,14 +506,15 @@ RSpec.describe HTTP::Headers do
     end
 
     context "with duplicate header keys (mixed case)" do
-      let(:headers) { {"Set-Cookie" => "hoo=ray", "set-cookie" => "woo=hoo"} }
+      let(:headers) { {"Set-Cookie" => "hoo=ray", "set_cookie" => "woo=hoo", :set_cookie => "ta=da"} }
 
       it "adds all headers" do
         expect(described_class.coerce(headers).to_a).
           to match_array(
             [
               %w[Set-Cookie hoo=ray],
-              %w[Set-Cookie woo=hoo]
+              %w[set_cookie woo=hoo],
+              %w[Set-Cookie ta=da]
             ]
           )
       end

--- a/spec/lib/http/options/headers_spec.rb
+++ b/spec/lib/http/options/headers_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe HTTP::Options, "headers" do
   end
 
   it "may be specified with with_headers" do
-    opts2 = opts.with_headers("accept" => "json")
+    opts2 = opts.with_headers(:accept => "json")
     expect(opts.headers).to be_empty
     expect(opts2.headers).to eq([%w[Accept json]])
   end

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe HTTP::Request::Writer do
       end
     end
 
+    context "when headers are specified as strings with mixed case" do
+      let(:headers) { HTTP::Headers.coerce "content-Type" => "text", "X_MAX" => "200" }
+
+      it "writes the headers with the same casing" do
+        writer.stream
+        expect(io.string).to eq [
+          "#{headerstart}\r\n",
+          "content-Type: text\r\nX_MAX: 200\r\nContent-Length: 0\r\n\r\n"
+        ].join
+      end
+    end
+
     context "when body is nonempty" do
       let(:body) { HTTP::Request::Body.new("content") }
 


### PR DESCRIPTION
The original behavior was to normalize all header names so that they
were broken up into words, delimited by `-` or `_`, capitalize each word,
and then join the words together with a `-`.

This made it impossible to make a request with an underscore (`_`) in the header
name, or with a different casing (ex: all caps).

However, the normalized name made it possible to access (or delete) headers,
without having to know the exact casing.

The new behavior is based on the following rules (as specified in https://github.com/httprb/http/issues/524#issuecomment-460014322)

1) Fail if a header name is not specified as a String or Symbol
2) If the header name is specified as a Symbol, normalize it when writing it in a request.
If the header name is specified as a String, preserve it as-is when writing it in a request.
3) Allow lookup of any header using the normalized form of the name

I implemented this behavior by storing three elements for each header value:
1) normalized header name
2) header name as it will be written in a request
3) header value

Element 2 is the new addition. I considered just storing the header value
as it would be written, and only doing normalization during lookup, but
it seemed wasteful to potentially normalize the same value over and over
when searching through the list for various lookups. This way we only
normalize each name once, and can continue to use that value for lookups.
However, whenever asked for the contents (ex: via `each` or `keys`) we
return the new, non-normalized name.

Fixes: https://github.com/httprb/http/issues/524