### PR TITLE
Duplicate options Hash in .timeout call

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -93,7 +93,7 @@ module HTTP
     def timeout(options)
       klass, options = case options
                        when Numeric then [HTTP::Timeout::Global, {:global => options}]
-                       when Hash    then [HTTP::Timeout::PerOperation, options]
+                       when Hash    then [HTTP::Timeout::PerOperation, options.dup]
                        when :null   then [HTTP::Timeout::Null, {}]
                        else raise ArgumentError, "Use `.timeout(global_timeout_in_seconds)` or `.timeout(connect: x, write: y, read: z)`."
 

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -307,6 +307,15 @@ RSpec.describe HTTP do
       end
     end
 
+    context "specifying per operation timeouts as frozen hash" do
+      let(:frozen_options) { {:read => 123}.freeze }
+      subject(:client) { HTTP.timeout(frozen_options) }
+
+      it "does not raise an error" do
+        expect { client }.not_to raise_error
+      end
+    end
+
     context "specifying a global timeout" do
       subject(:client) { HTTP.timeout 123 }
 


### PR DESCRIPTION
When `Hash` is passed to HTTP.timeout, it's been mutated. So when you pass
a frozen `Hash` it raises an exception.

Here is an example of the code:
```
timeout_settings = { connect: 5, write: 2, read: 10 }.freeze
HTTP.timeout(timeout_settings).get('http://example.com')
```

In this change, I have added a call to .dup on options Hash to create a
copy and avoid mutation of the original Hash.