### PR TITLE
Introduce proxy auto-detection based on ENV variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+/.idea/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,7 +34,7 @@ Metrics/BlockNesting:
 
 Metrics/ClassLength:
   CountComments: false
-  Max: 125
+  Max: 130
 
 # TODO: Lower to 6
 Metrics/CyclomaticComplexity:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 cache: bundler
 
 before_install:
-  - gem update --system
+  - yes | gem update --system
   - gem --version
   - gem install bundler
   - bundle --version

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -169,6 +169,11 @@ module HTTP
     end
     alias through via
 
+    # Use system defined proxy via ENV variables unless a valid proxy is present
+    def with_system_proxy
+      branch default_options.with_proxy(:proxy_auto_detect => true)
+    end
+
     # Make client follow redirects.
     # @param options
     # @return [HTTP::Client]

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -230,8 +230,14 @@ module HTTP
       headers
     end
 
-    def prepare_proxy(proxy)
-      proxy.is_a?(Request::Proxy) ? proxy : Request::Proxy.new(proxy, uri)
+    def prepare_proxy(object)
+      return object if object.is_a?(Request::Proxy)
+
+      proxy = Request::Proxy.new(object)
+      return proxy if proxy.available?
+      return Request::Proxy.auto_detect(uri) if object&.fetch(:proxy_auto_detect, false)
+
+      proxy
     end
   end
 end

--- a/lib/http/request/proxy.rb
+++ b/lib/http/request/proxy.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module HTTP
+  class Request
+    class Proxy
+      def initialize(proxy_params, request_uri)
+        @proxy = proxy_params || find_proxy(request_uri)
+      end
+
+      # @return [Boolean] Is there any proxy configuration available?
+      def available?
+        @proxy && @proxy.include?(:proxy_address) && @proxy.include?(:proxy_port)
+      end
+
+      # @return [Boolean] Does the proxy include authentication credentials?
+      def authenticated?
+        @proxy && @proxy.include?(:proxy_username) && @proxy.include?(:proxy_password)
+      end
+
+      # @return [Boolean] Does the proxy include additional request headers?
+      def include_headers?
+        @proxy.key?(:proxy_headers)
+      end
+
+      # @return [String, nil] Username (authentication credential)
+      def username
+        @proxy[:proxy_username]
+      end
+
+      # @return [String, nil] Password (authentication credential)
+      def password
+        @proxy[:proxy_password]
+      end
+
+      # @return [String, nil] Address
+      def address
+        @proxy[:proxy_address]
+      end
+
+      # @return [String, Integer, nil] Port
+      def port
+        @proxy[:proxy_port]
+      end
+
+      # @return [Hash, nil] Additional headers
+      def headers
+        @proxy[:proxy_headers]
+      end
+
+      private
+
+      def find_proxy(request_uri)
+        system_proxy = find_system_proxy(request_uri)
+
+        proxy = {}
+        proxy[:proxy_username] = system_proxy.user if system_proxy&.user
+        proxy[:proxy_password] = system_proxy.password if system_proxy&.password
+        proxy[:proxy_address] = system_proxy.host if system_proxy&.host
+        proxy[:proxy_port] = system_proxy.port if system_proxy&.port
+
+        proxy
+      end
+
+      def find_system_proxy(request_uri)
+        ::URI.parse(request_uri.to_s).find_proxy
+      end
+    end
+  end
+end

--- a/spec/lib/http/options/proxy_spec.rb
+++ b/spec/lib/http/options/proxy_spec.rb
@@ -17,4 +17,9 @@ RSpec.describe HTTP::Options, "proxy" do
     opts2 = opts.with_proxy(:proxy_address => "127.0.0.1", :proxy_port => 8080, :proxy_username => "username", :proxy_password => "password")
     expect(opts2.proxy).to eq(:proxy_address => "127.0.0.1", :proxy_port => 8080, :proxy_username => "username", :proxy_password => "password")
   end
+
+  it "accepts proxy auto_detection flag" do
+    opts2 = opts.with_proxy(:proxy_auto_detect => true)
+    expect(opts2.proxy).to eq(:proxy_auto_detect => true)
+  end
 end

--- a/spec/lib/http/request/proxy_spec.rb
+++ b/spec/lib/http/request/proxy_spec.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+RSpec.describe HTTP::Request::Proxy do
+  let(:request_uri) { HTTP::URI::NORMALIZER.call("http://www.example.org") }
+  let(:http_proxy_uri) { "http://douglas:adams@proxy.example.com:8001/" }
+  let(:proxy_params) { nil }
+  subject { described_class.new(proxy_params, request_uri) }
+
+  describe "#initialize" do
+    context "when no proxy are set" do
+      it "does not raise an error" do
+        expect { subject }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#available?" do
+    context "when no proxy are set" do
+      it "returns false" do
+        expect(subject.available?).to be_falsey
+      end
+    end
+
+    context "when proxy is set by the user" do
+      let(:proxy_params) { {:proxy_address => "proxy.example.com", :proxy_port => 8001} }
+
+      it "returns true" do
+        expect(subject.available?).to be_truthy
+      end
+    end
+
+    context "when proxy is set by env variables" do
+      it "returns true" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri)
+
+        expect(subject.available?).to be_truthy
+      end
+
+      it "returns false when proxy schema is different to request_uri" do
+        stub_const("ENV", "https_proxy" => http_proxy_uri)
+
+        expect(subject.available?).to be_falsey
+      end
+    end
+
+    context "when no_proxy is set by env variable" do
+      it "returns false when no_proxy matches request_uri" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
+
+        expect(subject.available?).to be_falsey
+      end
+    end
+  end
+
+  describe "#authenticated?" do
+    context "when no credentials are set" do
+      it "returns false" do
+        expect(subject.authenticated?).to be_falsey
+      end
+    end
+
+    context "when credentials are set by the user" do
+      let(:proxy_params) { {:proxy_username => "douglas", :proxy_password => "adams"} }
+
+      it "returns true" do
+        expect(subject.authenticated?).to be_truthy
+      end
+    end
+
+    context "when credentials are set by env variables" do
+      it "returns true" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri)
+
+        expect(subject.authenticated?).to be_truthy
+      end
+
+      it "returns false when no_proxy matches request_uri" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
+
+        expect(subject.authenticated?).to be_falsey
+      end
+
+      it "returns false when proxy schema is different to request_uri" do
+        stub_const("ENV", "https_proxy" => http_proxy_uri)
+
+        expect(subject.authenticated?).to be_falsey
+      end
+    end
+  end
+
+  describe "#include_headers?" do
+    context "when no extra headers are set by the user" do
+      it "returns false" do
+        expect(subject.include_headers?).to be_falsey
+      end
+    end
+
+    context "when extra headers are set by the user" do
+      let(:proxy_params) { {:proxy_headers => {"X-Forwarded-For" => "127.0.0.1"}} }
+
+      it "returns true" do
+        expect(subject.include_headers?).to be_truthy
+      end
+    end
+  end
+
+  describe "#username" do
+    context "when no credentials are set" do
+      it "returns nil" do
+        expect(subject.username).to be_nil
+      end
+    end
+
+    context "when credentials are set by the user" do
+      let(:proxy_params) { {:proxy_username => "douglas", :proxy_password => "adams"} }
+
+      it "returns the username set by the user" do
+        expect(subject.username).to eq("douglas")
+      end
+    end
+
+    context "when credentials are set by env variables" do
+      it "returns the username set by the proxy env variable" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri)
+
+        expect(subject.username).to eq("douglas")
+      end
+
+      it "returns nil when proxy schema is different to request_uri" do
+        stub_const("ENV", "https_proxy" => http_proxy_uri)
+
+        expect(subject.password).to be_nil
+      end
+
+      it "returns nil when no_proxy matches request_uri" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
+
+        expect(subject.username).to be_nil
+      end
+    end
+  end
+
+  describe "#password" do
+    context "when no credentials are set" do
+      it "returns nil" do
+        expect(subject.password).to be_nil
+      end
+    end
+
+    context "when credentials are set by the user" do
+      let(:proxy_params) { {:proxy_username => "douglas", :proxy_password => "adams"} }
+
+      it "returns the username set by the user" do
+        expect(subject.password).to eq("adams")
+      end
+    end
+
+    context "when credentials are set by env variables" do
+      it "returns the username set by the proxy env variable" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri)
+
+        expect(subject.password).to eq("adams")
+      end
+
+      it "returns nil when proxy schema is different to request_uri" do
+        stub_const("ENV", "https_proxy" => http_proxy_uri)
+
+        expect(subject.password).to be_nil
+      end
+
+      it "returns nil when no_proxy matches request_uri" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
+
+        expect(subject.password).to be_nil
+      end
+    end
+  end
+
+  describe "#address" do
+    context "when not set" do
+      it "returns nil" do
+        expect(subject.address).to be_nil
+      end
+    end
+
+    context "when set by the user" do
+      let(:proxy_params) { {:proxy_address => "proxy.example.com", :proxy_port => "8001"} }
+
+      it "returns the proxy address set by the user" do
+        expect(subject.address).to eq("proxy.example.com")
+      end
+    end
+
+    context "when proxy is set by env variables" do
+      it "returns the proxy address set by env variables" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri)
+
+        expect(subject.address).to eq("proxy.example.com")
+      end
+
+      it "returns nil when proxy schema is different to request_uri" do
+        stub_const("ENV", "https_proxy" => http_proxy_uri)
+
+        expect(subject.address).to be_nil
+      end
+
+      it "returns nil when no_proxy matches request_uri" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
+
+        expect(subject.address).to be_nil
+      end
+    end
+  end
+
+  describe "#port" do
+    context "when not set" do
+      it "returns nil" do
+        expect(subject.port).to be_nil
+      end
+    end
+
+    context "when set by the user" do
+      let(:proxy_params) { {:proxy_address => "proxy.example.com", :proxy_port => 8001} }
+
+      it "returns the proxy address set by the user" do
+        expect(subject.port).to eq(8001)
+      end
+    end
+
+    context "when proxy is set by env variables" do
+      it "returns the proxy address set by env variables" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri)
+
+        expect(subject.port).to eq(8001)
+      end
+
+      it "returns nil when proxy schema is different to request_uri" do
+        stub_const("ENV", "https_proxy" => http_proxy_uri)
+
+        expect(subject.port).to be_nil
+      end
+
+      it "returns nil when no_proxy matches request_uri" do
+        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
+
+        expect(subject.port).to be_nil
+      end
+    end
+  end
+
+  describe "#headers" do
+    context "when not set" do
+      it "returns nil" do
+        expect(subject.headers).to eq(nil)
+      end
+    end
+
+    context "when set by the user" do
+      let(:proxy_params) { {:proxy_headers => {"X-Forwarded-For" => "127.0.0.1"}} }
+
+      it "returns the extra headers set by the user" do
+        expect(subject.headers).to eq("X-Forwarded-For" => "127.0.0.1")
+      end
+    end
+  end
+end

--- a/spec/lib/http/request/proxy_spec.rb
+++ b/spec/lib/http/request/proxy_spec.rb
@@ -4,7 +4,33 @@ RSpec.describe HTTP::Request::Proxy do
   let(:request_uri) { HTTP::URI::NORMALIZER.call("http://www.example.org") }
   let(:http_proxy_uri) { "http://douglas:adams@proxy.example.com:8001/" }
   let(:proxy_params) { nil }
-  subject { described_class.new(proxy_params, request_uri) }
+  subject { described_class.new(proxy_params) }
+
+  describe ".auto_detect" do
+    subject { described_class.auto_detect(request_uri) }
+
+    it "detects proxy params when schema matches with request_uri" do
+      stub_const("ENV", "http_proxy" => http_proxy_uri)
+
+      expect(subject.available?).to be_truthy
+      expect(subject.address).to eq("proxy.example.com")
+      expect(subject.port).to eq(8001)
+      expect(subject.username).to eq("douglas")
+      expect(subject.password).to eq("adams")
+    end
+
+    it "returns unavailable proxy when schema differs from request_uri" do
+      stub_const("ENV", "https_proxy" => http_proxy_uri)
+
+      expect(subject.available?).to be_falsey
+    end
+
+    it "returns unavailable proxy when no_proxy matches request_uri" do
+      stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
+
+      expect(subject.available?).to be_falsey
+    end
+  end
 
   describe "#initialize" do
     context "when no proxy are set" do
@@ -28,28 +54,6 @@ RSpec.describe HTTP::Request::Proxy do
         expect(subject.available?).to be_truthy
       end
     end
-
-    context "when proxy is set by env variables" do
-      it "returns true" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri)
-
-        expect(subject.available?).to be_truthy
-      end
-
-      it "returns false when proxy schema is different to request_uri" do
-        stub_const("ENV", "https_proxy" => http_proxy_uri)
-
-        expect(subject.available?).to be_falsey
-      end
-    end
-
-    context "when no_proxy is set by env variable" do
-      it "returns false when no_proxy matches request_uri" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
-
-        expect(subject.available?).to be_falsey
-      end
-    end
   end
 
   describe "#authenticated?" do
@@ -64,26 +68,6 @@ RSpec.describe HTTP::Request::Proxy do
 
       it "returns true" do
         expect(subject.authenticated?).to be_truthy
-      end
-    end
-
-    context "when credentials are set by env variables" do
-      it "returns true" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri)
-
-        expect(subject.authenticated?).to be_truthy
-      end
-
-      it "returns false when no_proxy matches request_uri" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
-
-        expect(subject.authenticated?).to be_falsey
-      end
-
-      it "returns false when proxy schema is different to request_uri" do
-        stub_const("ENV", "https_proxy" => http_proxy_uri)
-
-        expect(subject.authenticated?).to be_falsey
       end
     end
   end
@@ -118,26 +102,6 @@ RSpec.describe HTTP::Request::Proxy do
         expect(subject.username).to eq("douglas")
       end
     end
-
-    context "when credentials are set by env variables" do
-      it "returns the username set by the proxy env variable" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri)
-
-        expect(subject.username).to eq("douglas")
-      end
-
-      it "returns nil when proxy schema is different to request_uri" do
-        stub_const("ENV", "https_proxy" => http_proxy_uri)
-
-        expect(subject.password).to be_nil
-      end
-
-      it "returns nil when no_proxy matches request_uri" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
-
-        expect(subject.username).to be_nil
-      end
-    end
   end
 
   describe "#password" do
@@ -152,26 +116,6 @@ RSpec.describe HTTP::Request::Proxy do
 
       it "returns the username set by the user" do
         expect(subject.password).to eq("adams")
-      end
-    end
-
-    context "when credentials are set by env variables" do
-      it "returns the username set by the proxy env variable" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri)
-
-        expect(subject.password).to eq("adams")
-      end
-
-      it "returns nil when proxy schema is different to request_uri" do
-        stub_const("ENV", "https_proxy" => http_proxy_uri)
-
-        expect(subject.password).to be_nil
-      end
-
-      it "returns nil when no_proxy matches request_uri" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
-
-        expect(subject.password).to be_nil
       end
     end
   end
@@ -190,26 +134,6 @@ RSpec.describe HTTP::Request::Proxy do
         expect(subject.address).to eq("proxy.example.com")
       end
     end
-
-    context "when proxy is set by env variables" do
-      it "returns the proxy address set by env variables" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri)
-
-        expect(subject.address).to eq("proxy.example.com")
-      end
-
-      it "returns nil when proxy schema is different to request_uri" do
-        stub_const("ENV", "https_proxy" => http_proxy_uri)
-
-        expect(subject.address).to be_nil
-      end
-
-      it "returns nil when no_proxy matches request_uri" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
-
-        expect(subject.address).to be_nil
-      end
-    end
   end
 
   describe "#port" do
@@ -224,26 +148,6 @@ RSpec.describe HTTP::Request::Proxy do
 
       it "returns the proxy address set by the user" do
         expect(subject.port).to eq(8001)
-      end
-    end
-
-    context "when proxy is set by env variables" do
-      it "returns the proxy address set by env variables" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri)
-
-        expect(subject.port).to eq(8001)
-      end
-
-      it "returns nil when proxy schema is different to request_uri" do
-        stub_const("ENV", "https_proxy" => http_proxy_uri)
-
-        expect(subject.port).to be_nil
-      end
-
-      it "returns nil when no_proxy matches request_uri" do
-        stub_const("ENV", "http_proxy" => http_proxy_uri, "no_proxy" => "example.org")
-
-        expect(subject.port).to be_nil
       end
     end
   end

--- a/spec/lib/http/request_spec.rb
+++ b/spec/lib/http/request_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe HTTP::Request do
     end
 
     context "with proxy" do
-      let(:proxy) { {:user => "user", :pass => "pass"} }
+      let(:proxy) { {:proxy_address => "proxy.example.com", :proxy_port => "8001"} }
       it { is_expected.to eq "GET http://example.com/foo?bar=baz HTTP/1.1" }
 
       context "and HTTPS uri" do


### PR DESCRIPTION
Auto-detection is based on standard ENV variables used in a UNIX system.
Some documentation can be seen here:
https://www.gnu.org/software/wget/manual/html_node/Proxies.html

The most common and used are "#{schema}_proxy" and no_proxy, but it also
supports other non-recommended formats covered by Ruby URI library.

Fix #356