### PR TITLE
Ruby 2.7 compatibility

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -93,7 +93,7 @@ module HTTP
       chunk    = @parser.read(size)
       finish_response if finished
 
-      chunk.to_s
+      chunk || "".b
     end
 
     # Reads data from socket up until headers are loaded

--- a/lib/http/features/auto_deflate.rb
+++ b/lib/http/features/auto_deflate.rb
@@ -10,7 +10,7 @@ module HTTP
     class AutoDeflate < Feature
       attr_reader :method
 
-      def initialize(*)
+      def initialize(**)
         super
 
         @method = @opts.key?(:method) ? @opts[:method].to_s : "gzip"

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -111,7 +111,7 @@ module HTTP
                     unless (feature = self.class.available_features[name])
                       argument_error! "Unsupported feature: #{name}"
                     end
-                    feature.new(opts_or_feature)
+                    feature.new(**opts_or_feature)
                   end
       end
     end


### PR DESCRIPTION
In Ruby 2.7 `Nil#to_s` returns a frozen string, so we make sure to return a mutable string in `Connection#readpartial`, allowing it to be mutated in `Response::Body#to_s` (otherwise a `FrozenError` exception is raised). I thought about just returning `nil` instead, but I didn't want to break anything.

We also fix warnings around keyword arguments, as Ruby 2.7 wants us to be explicit about whether we're passing kwargs or hashes, as that will be the behaviour in Ruby 3.0.

Only one spec still fails, related to `http-form_data`, for which I've sent the PR in https://github.com/httprb/form_data/pull/28.

Btw, I also tried to see if we can replace CertificateAuthority with [Localhost](https://github.com/socketry/localhost) to remove the warnings, as the latter is much simpler and is actually maintained. I think it can be done, but it turned out to be more work than I expected, so better to do that in a separate PR.