### PR TITLE
Add digest auth feature

### DIFF
--- a/lib/http/features/digest.rb
+++ b/lib/http/features/digest.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "net/http/digest_auth"
+
+module HTTP
+  module Features
+    class Digest < Feature
+      def wrap_response(response)
+        if response.status.code == 401
+          digest = Net::HTTP::DigestAuth.new
+          auth = digest.auth_header(response.request.uri, response["WWW-Authenticate"], response.request.verb.to_s.upcase)
+          response = HTTP.auth(auth).get(response.request.uri)
+        end
+        response
+      end
+
+      HTTP::Options.register_feature(:digest, self)
+    end
+  end
+end


### PR DESCRIPTION
This is a decent start (it works) but there's a few problems to be solved:
- Should this be a feature or a modification of HTTP::Client?
- How do I access the HTTP client that was used to make the request? Right now I used `HTTP` but we need to reuse the original one, with user options, etc.