### PR TITLE
Bump http-form_data dependency to 2.2+

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "addressable",    "~> 2.3"
   gem.add_runtime_dependency "http-cookie",    "~> 1.0"
-  gem.add_runtime_dependency "http-form_data", "~> 2.0"
+  gem.add_runtime_dependency "http-form_data", "~> 2.2"
   gem.add_runtime_dependency "http-parser",    "~> 1.2.0"
 
   gem.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
`http-form_data` 2.2.0 addresses Ruby 2.7 compatibility (see https://github.com/httprb/form_data/pull/28), so I think it makes sense to ensure `http` requires at least that version.

This should be the last thing needed for Ruby 2.7 compatibility.