### PR TITLE
Add info response support

### DIFF
--- a/lib/http/response/parser.rb
+++ b/lib/http/response/parser.rb
@@ -86,7 +86,11 @@ module HTTP
       end
 
       def on_message_complete(_response)
-        @finished[:message] = true
+        if @state.http_status < 200
+          reset
+        else
+          @finished[:message] = true
+        end
       end
 
       def reset

--- a/spec/lib/http/response/parser_spec.rb
+++ b/spec/lib/http/response/parser_spec.rb
@@ -42,4 +42,33 @@ RSpec.describe HTTP::Response::Parser do
       expect(subject.read(expected_body.size)).to eq(expected_body)
     end
   end
+
+  context "when got 100 Continue response" do
+    let :raw_response do
+      "HTTP/1.1 100 Continue\r\n\r\n" \
+      "HTTP/1.1 200 OK\r\n" \
+      "Content-Length: 12\r\n\r\n" \
+      "Hello World!"
+    end
+
+    context "when response is feeded in one part" do
+      let(:parts) { [raw_response] }
+
+      it "skips to next non-info response" do
+        expect(subject.status_code).to eq(200)
+        expect(subject.headers).to eq("Content-Length" => "12")
+        expect(subject.read(12)).to eq("Hello World!")
+      end
+    end
+
+    context "when response is feeded in many parts" do
+      let(:parts) { raw_response.split(//) }
+
+      it "skips to next non-info response" do
+        expect(subject.status_code).to eq(200)
+        expect(subject.headers).to eq("Content-Length" => "12")
+        expect(subject.read(12)).to eq("Hello World!")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This patch adds support for 1XX informational responses. Those kinds of responses are sent along with normal responses, and flow looks like:

    > GET / HTTP/1.1
    > Host: example.com
    >

    < HTTP/1.1 100 Continue
    < HTTP/1.1 200 OK
    < Content-Length: 12
    <
    < Hello World!

Notice that server responds (sends to the socket) 2 HTTP responses.

---

Resolves: #592