### PR TITLE
Reflect that Ruby 2.7.x is being tested on CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ versions:
 * Ruby 2.4.x
 * Ruby 2.5.x
 * Ruby 2.6.x
+* Ruby 2.7.x
 * JRuby 9.2.x.x
 
 If something doesn't work on one of these versions, it's a bug.


### PR DESCRIPTION
Fairly self explanatory. Ruby 2.7.x is already being tested in Travis, but the `README` does not yet reflect that there is official support. 🙂 