### PR TITLE
Allow passing HTTP::FormData object to HTTP::Client directly

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -175,7 +175,7 @@ module HTTP
       when opts.body
         opts.body
       when opts.form
-        form = HTTP::FormData.create opts.form
+        form = form_data(opts.form)
         headers[Headers::CONTENT_TYPE] ||= form.content_type
         form
       when opts.json
@@ -183,6 +183,10 @@ module HTTP
         headers[Headers::CONTENT_TYPE] ||= "application/json; charset=#{body.encoding.name}"
         body
       end
+    end
+
+    def form_data(form)
+      (form || {}).respond_to?(:to_h) ? HTTP::FormData.create(form) : form
     end
   end
 end

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe HTTP::Client do
           expect(opts[:body].to_s).to eq "foo=bar"
         end
 
-        client.get("http://example.com/", :form => HTTP::FormData.create({ :foo => "bar" }))
+        client.get("http://example.com/", :form => HTTP::FormData.create(:foo => "bar"))
       end
     end
   end

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -197,6 +197,20 @@ RSpec.describe HTTP::Client do
 
       client.get("http://example.com/", :form => {:foo => HTTP::FormData::Part.new("content")})
     end
+
+    context "when passing an HTTP::FormData object directly" do
+      it "creates url encoded form data object" do
+        client = HTTP::Client.new
+        allow(client).to receive(:perform)
+
+        expect(HTTP::Request).to receive(:new) do |opts|
+          expect(opts[:body]).to be_a(HTTP::FormData::Urlencoded)
+          expect(opts[:body].to_s).to eq "foo=bar"
+        end
+
+        client.get("http://example.com/", :form => HTTP::FormData.create({ :foo => "bar" }))
+      end
+    end
   end
 
   describe "passing json" do


### PR DESCRIPTION
As discussed with @ixti  in https://github.com/httprb/form_data/pull/29, this allows you to pass an `HTTP::FormData` object directly instead of a `Hash` for more customization such as using a custom encoder. Example:

```ruby
custom_encoder = proc { |data| ::JSON.dump(data) }
data = { "foo[bar]" => "test" }
form_data = HTTP::FormData.create(data, encoder: custom_encoder)
HTTP.post("https://some-url.com", form: form_data)
```

Note that I decided to use the following logic to determine whether an `HTTP::FormData` object was being passed in directly:

```ruby
    def form_data(form)
      (form || {}).respond_to?(:to_h) ? HTTP::FormData.create(form) : form
    end
```

The other option would be to check if `form` `is_a?` `HTTP::FormData::Urlencoded` or a `HTTP::FormData::Multipart` but this seemed less flexible since it creates a coupling with what's returned from `HTTP::FormData.create`. However, I don't have a strong opinion here and am happy to change if another method is more desirable.