### PR TITLE
Add on_redirect callback option to follow.

### DIFF
--- a/lib/http/redirector.rb
+++ b/lib/http/redirector.rb
@@ -40,8 +40,9 @@ module HTTP
     # @option opts [Boolean] :strict (true) redirector hops policy
     # @option opts [#to_i] :max_hops (5) maximum allowed amount of hops
     def initialize(opts = {}) # rubocop:disable Style/OptionHash
-      @strict   = opts.fetch(:strict, true)
-      @max_hops = opts.fetch(:max_hops, 5).to_i
+      @strict      = opts.fetch(:strict, true)
+      @max_hops    = opts.fetch(:max_hops, 5).to_i
+      @on_redirect = opts.fetch(:on_redirect, nil)
     end
 
     # Follows redirects until non-redirect response found
@@ -95,6 +96,8 @@ module HTTP
       end
 
       verb = :get if !SEE_OTHER_ALLOWED_VERBS.include?(verb) && 303 == code
+
+      @on_redirect.call @response, uri if @on_redirect.respond_to?(:call)
 
       @request.redirect(uri, verb)
     end


### PR DESCRIPTION
Hello,

I'm interested in caching permanent redirects. I was wondering if you would accept this feature that adds support for passing an `on_redirect` option to `follow`. The `on_redirect` option accepts a proc. For example:

```ruby
HTTP.follow(on_redirect: proc { |response, location| cache(location) })
  .get("http://example.com/redirect")
```

This way http can report any redirects it follows.

Thanks!