### PR TITLE
Use stateful CookieJar in Redirector

### DIFF
--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -97,9 +97,10 @@ module HTTP
     end
 
     # Returns new Request with updated uri
-    def redirect(uri, verb = @verb)
+    def redirect(uri, verb = @verb, cookies_raw: nil)
       headers = self.headers.dup
       headers.delete(Headers::HOST)
+      headers[Headers::COOKIE] = cookies_raw if cookies_raw
 
       self.class.new(
         :verb           => verb,


### PR DESCRIPTION
As [mentioned](../issues/264#issuecomment-157070867) in #264, CookieJar
implements cookie domain scoping rules, which is useful when issuing
redirects across domains.

Resolves: #264