### PR TITLE
Inflater handle empty streams

### DIFF
--- a/lib/http/response/inflater.rb
+++ b/lib/http/response/inflater.rb
@@ -16,7 +16,7 @@ module HTTP
         if chunk
           chunk = zstream.inflate(chunk)
         elsif !zstream.closed?
-          zstream.finish
+          zstream.finish if zstream.total_in.positive?
           zstream.close
         end
         chunk

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -438,6 +438,22 @@ RSpec.describe HTTP do
 
         expect(response.to_s).to eq("#{body}-deflated")
       end
+
+      it "returns empty body for no content response where Content-Encoding is gzip" do
+        client   = HTTP.use(:auto_inflate).headers("Accept-Encoding" => "gzip")
+        body     = "Hello!"
+        response = client.post("#{dummy.endpoint}/no-content-204", :body => body)
+
+        expect(response.to_s).to eq("")
+      end
+
+      it "returns empty body for no content response where Content-Encoding is deflate" do
+        client   = HTTP.use(:auto_inflate).headers("Accept-Encoding" => "deflate")
+        body     = "Hello!"
+        response = client.post("#{dummy.endpoint}/no-content-204", :body => body)
+
+        expect(response.to_s).to eq("")
+      end
     end
 
     context "with :normalize_uri" do

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -172,5 +172,17 @@ class DummyServer < WEBrick::HTTPServer
                    "#{req.body}-raw"
                  end
     end
+
+    post "/no-content-204" do |req, res|
+      res.status = 204
+      res.body   = ""
+
+      case req["Accept-Encoding"]
+      when "gzip" then
+        res["Content-Encoding"] = "gzip"
+      when "deflate" then
+        res["Content-Encoding"] = "deflate"
+      end
+    end
   end
 end


### PR DESCRIPTION
Hello,
This prevents the issue of Zlib::BufError errors raised when reading
by Inflater empty streams (should fix #624).

Thanks!