### PR TITLE
Respect the SSL context's verify_hostname value

### DIFF
--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -37,7 +37,7 @@ module HTTP
 
         return unless ssl_context.verify_mode == OpenSSL::SSL::VERIFY_PEER
 
-        @socket.post_connection_check(host)
+        @socket.post_connection_check(host) if ssl_context.verify_hostname
       end
 
       # Read from the socket


### PR DESCRIPTION
I stumbled upon an issue where http.rb wouldn't respect the `verify_hostname` value of the current OpenSSL::SSL::SSLContext.

Previously we would unconditionally call [post_connection_check](https://github.com/ruby/openssl/blob/fd39183a61483c9b2b05aa5837a8185a522da653/lib/openssl/ssl.rb#L392), whose only purpose is to verify hostnames, regardless of what `verify_hostname` was set to. This results in quite a bit of user confusion since one expects hostname verification to be handled by OpenSSL itself rather than by the HTTP library.

Digging through the blames, it looks like this was never implemented properly. Ruby's Net::HTTP [fixed the same issue with this pull](https://github.com/ruby/ruby/pull/2858/commits/883693ce069c046c2e64e6449e5fb19660c8e21b#diff-a1d29a94def02829fd4f9ba591199acf079e028f5a2002a77c363eb01212e112R1018) in January.

This simple change fixes the issue for me and brings http.rb in line with the other Ruby HTTP libraries.