### PR TITLE
Make SSL hostname verification default to on

### DIFF
--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -36,7 +36,7 @@ module HTTP
         connect_ssl
 
         return unless ssl_context.verify_mode == OpenSSL::SSL::VERIFY_PEER
-        return unless ssl_context.respond_to?(:verify_hostname) && ssl_context.verify_hostname
+        return if ssl_context.respond_to?(:verify_hostname) && !ssl_context.verify_hostname
 
         @socket.post_connection_check(host)
       end


### PR DESCRIPTION
Following up on this comment:

https://github.com/httprb/http/pull/634#pullrequestreview-559142562

The previous logic skipped hostname verification entirely if the `verify_hostname` method is not defined for `OpenSSL::SSL::SSLContext`, which is currently the case for JRuby.

This commit changes the logic so if that method is undefined, hostname verification is still performed. Otherwise, hostname verification would always be skipped on Rubies which don't define a `verify_hostname` method.

Note that this was *just* introduced in #634 which was merged 10 hours ago, so I think this was caught quickly enough simply correcting it suffices and there isn't additional security-related followup here (e.g. CVE)