### PR TITLE
DNS failover handling

### DIFF
--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "resolv"
 require "timeout"
 
 require "http/timeout/null"
@@ -17,12 +18,29 @@ module HTTP
         @read_timeout = options.fetch(:read_timeout, READ_TIMEOUT)
         @write_timeout = options.fetch(:write_timeout, WRITE_TIMEOUT)
         @connect_timeout = options.fetch(:connect_timeout, CONNECT_TIMEOUT)
+        @dns_resolver = options.fetch(:dns_resolver) do
+          ::Resolv.method(:getaddresses)
+        end
       end
 
-      def connect(socket_class, host, port, nodelay = false)
-        ::Timeout.timeout(@connect_timeout, TimeoutError) do
-          @socket = socket_class.open(host, port)
-          @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1) if nodelay
+      def connect(socket_class, host_name, *args)
+        connect_operation = lambda do |host_address|
+          ::Timeout.timeout(@connect_timeout, TimeoutError) do
+            super(socket_class, host_address, *args)
+          end
+        end
+        host_addresses = @dns_resolver.call(host_name)
+        # ensure something to iterates
+        trying_targets = host_addresses.empty? ? [host_name] : host_addresses
+        trying_iterator = trying_targets.lazy
+        error = nil
+        begin
+          connect_operation.call(trying_iterator.next)
+        rescue TimeoutError => e
+          error = e
+          retry
+        rescue ::StopIteration
+          raise error
         end
       end
 


### PR DESCRIPTION
Hello there,

I want to add DNS failover support for the client.  
This implementation inclined with Nginx's behavior when used as a reverse proxy.

I need help adding the required specs; if someone wants to help, please send a pull request to my branch.

For some context, some services use [A records](https://en.wikipedia.org/wiki/List_of_DNS_record_types) with multiple IP addresses, unless you are large enough to handles failover at the [BGP](https://en.wikipedia.org/wiki/Border_Gateway_Protocol) level, this is the only practical way to eliminate a single point of failure.  
But the failover technique needs client support, hence the pull request.