### PR TITLE
Initial implementation for llparser binding

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "http-cookie",    "~> 1.0"
   gem.add_runtime_dependency "http-form_data", "~> 2.2"
   gem.add_runtime_dependency "http-parser",    "~> 1.2.0"
+  gem.add_runtime_dependency "llhttp"
 
   gem.add_development_dependency "bundler", "~> 2.0"
 

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -3,7 +3,7 @@
 require "forwardable"
 
 require "http/headers"
-require "http/response/parser"
+require "http/response/llparser"
 
 module HTTP
   # A connection to the HTTP server
@@ -37,7 +37,7 @@ module HTTP
       @failed_proxy_connect = false
       @buffer               = "".b
 
-      @parser = Response::Parser.new
+      @parser = Response::LLParser.new
 
       @socket = options.timeout_class.new(options.timeout_options)
       @socket.connect(options.socket_class, req.socket_host, req.socket_port, options.nodelay)

--- a/lib/http/response/llparser.rb
+++ b/lib/http/response/llparser.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "llhttp"
+
+module HTTP
+  class Response
+    # @api private
+
+    class LLParsingHandler < ::LLHttp::Delegate
+      def initialize(target)
+        @target = target
+        super()
+        reset
+      end
+
+      def reset
+        @header_field = nil
+      end
+
+      def on_header_field(field)
+        @header_field = field
+      end
+
+      def on_header_value(value)
+        return unless @header_field
+        @target.add_header(@header_field, value)
+        @header_field = nil
+      end
+
+      def on_headers_complete
+        @target.status_code = @target.parser.status_code
+        @target.http_version = "#{@target.parser.http_major}.#{@target.parser.http_minor}"
+        @target.mark_header_finished
+      end
+
+      def on_body(body)
+        @target.add_body(body)
+      end
+
+      def on_message_complete
+        @target.mark_message_finished
+      end
+    end
+
+    class LLParser
+      attr_reader \
+        :parser,
+        :headers
+      attr_accessor \
+        :status_code,
+        :http_version
+
+      def initialize
+        @parsing_handler = LLParsingHandler.new(self)
+        @parser = ::LLHttp::Parser.new(
+          @parsing_handler,
+          type: :response
+        )
+        reset
+      end
+
+      def reset
+        @parsing_handler.reset
+        @header_finished = false
+        @message_finished = false
+        @headers = Headers.new
+        @body_buffer&.close
+        @body_buffer&.clear
+        @body_buffer = ::Queue.new
+        @read_buffer = ""
+      end
+
+      # @return [self]
+      def add(data)
+        (parser << data).tap do |success|
+          raise IOError, "Could not parse data" unless success
+          break self
+        end
+      end
+
+      alias << add
+
+      def mark_header_finished
+        @header_finished = true
+      end
+
+      def headers?
+        @header_finished
+      end
+
+      def add_header(name, value)
+        @headers.add(name, value)
+      end
+
+      def mark_message_finished
+        @message_finished = true
+        @body_buffer.close if @body_buffer.respond_to?(:close)
+      end
+
+      def finished?
+        @message_finished
+      end
+
+      def add_body(chunk)
+        @body_buffer.enq(chunk)
+      end
+
+      def read(size)
+        loop do
+          @read_buffer = "#{@read_buffer}#{@body_buffer.deq(true)}"
+          break if size <= @read_buffer.bytesize
+        rescue ::StopIteration, ::ThreadError
+          break
+        end
+        @read_buffer.byteslice(0, size).tap do |chunk|
+          @read_buffer = @read_buffer.byteslice(
+            (size)...(@read_buffer.bytesize)
+          ) || ""
+          break nil if chunk.empty?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello,  
And ping https://github.com/httprb/http/issues/604, https://github.com/httprb/http/issues/630, https://github.com/httprb/http/issues/622.

I tried hooking the llparser in; it is actually not that hard.  
I almost got every test passed; only one failed.

The test that failed is in `client_spec.rb`. The context is: "with broken body (too early closed connection)".
The failure seems to be related to the error raised in the old `parser.rb` in `add` method.  
I have no idea how this thing works, maybe a leaky abstraction?

On the implementation details
I used https://github.com/metabahn/llhttp, which is not quite production-ready.
The gem did not handle the compilation properly and required some patch to work with `http.rb`.
The patch in question is minimal, just:
~~~c
VALUE rb_llhttp_http_major(VALUE self) {
  llhttp_t *parser;

  Data_Get_Struct(self, llhttp_t, parser);

  return UINT2NUM(parser->http_major);
}

VALUE rb_llhttp_http_minor(VALUE self) {
  llhttp_t *parser;

  Data_Get_Struct(self, llhttp_t, parser);

  return UINT2NUM(parser->http_minor);
}
~~~
and
~~~c
  rb_define_method(cParser, "http_major", rb_llhttp_http_major, 0);
  rb_define_method(cParser, "http_minor", rb_llhttp_http_minor, 0);
~~~
For testing, you have to compile the extension manually after patching.

In summary, replacing the gem should not take that long, and this PR can be a starting point.