### PR TITLE
Add support for the MKCALENDAR HTTP verb

### DIFF
--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -46,7 +46,10 @@ module HTTP
       :patch,
 
       # draft-reschke-webdav-search: WebDAV Search
-      :search
+      :search,
+
+      # RFC 4791: Calendaring Extensions to WebDAV -- CalDAV
+      :mkcalendar
     ].freeze
 
     # Allowed schemes


### PR DESCRIPTION
This is to support the RFC4791 Calendaring Extensions to WebDAV (aka, CalDAV), allowing a client to create a new calendar on a CalDAV server.
