### PR TITLE
Avoid force encoding on frozen strings

### DIFF
--- a/lib/http/response/body.rb
+++ b/lib/http/response/body.rb
@@ -27,7 +27,9 @@ module HTTP
       # (see HTTP::Client#readpartial)
       def readpartial(*args)
         stream!
-        @stream.readpartial(*args)&.force_encoding(@encoding)
+        chunk = @stream.readpartial(*args)
+
+        String.new(chunk, :encoding => @encoding) if chunk
       end
 
       # Iterate over the body, allowing it to be enumerable
@@ -45,11 +47,11 @@ module HTTP
 
         begin
           @streaming  = false
-          @contents   = String.new("").force_encoding(@encoding)
+          @contents   = String.new("", :encoding => @encoding)
 
           while (chunk = @stream.readpartial)
-            @contents << chunk.force_encoding(@encoding)
-            chunk.clear # deallocate string
+            @contents << String.new(chunk, :encoding => @encoding)
+            chunk = nil # deallocate string
           end
         rescue
           @contents = nil

--- a/spec/lib/http/response/body_spec.rb
+++ b/spec/lib/http/response/body_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe HTTP::Response::Body do
   let(:connection) { double(:sequence_id => 0) }
-  let(:chunks)     { [String.new("Hello, "), String.new("World!")] }
+  let(:chunks)     { ["Hello, ", "World!"] }
 
   before do
     allow(connection).to receive(:readpartial) { chunks.shift }
@@ -16,7 +16,7 @@ RSpec.describe HTTP::Response::Body do
   end
 
   context "when body empty" do
-    let(:chunks) { [String.new("")] }
+    let(:chunks) { [""] }
 
     it "returns responds to empty? with true" do
       expect(subject).to be_empty
@@ -45,12 +45,12 @@ RSpec.describe HTTP::Response::Body do
     it "returns content in specified encoding" do
       body = described_class.new(connection)
       expect(connection).to receive(:readpartial).
-        and_return(String.new("content").force_encoding(Encoding::UTF_8))
+        and_return(String.new("content", :encoding => Encoding::UTF_8))
       expect(body.readpartial.encoding).to eq Encoding::BINARY
 
       body = described_class.new(connection, :encoding => Encoding::UTF_8)
       expect(connection).to receive(:readpartial).
-        and_return(String.new("content").force_encoding(Encoding::BINARY))
+        and_return(String.new("content", :encoding => Encoding::BINARY))
       expect(body.readpartial.encoding).to eq Encoding::UTF_8
     end
   end
@@ -59,7 +59,7 @@ RSpec.describe HTTP::Response::Body do
     let(:chunks) do
       body = Zlib::Deflate.deflate("Hi, HTTP here ☺")
       len  = body.length
-      [String.new(body[0, len / 2]), String.new(body[(len / 2)..-1])]
+      [body[0, len / 2], body[(len / 2)..-1]]
     end
     subject(:body) do
       inflater = HTTP::Response::Inflater.new(connection)


### PR DESCRIPTION
using the gem [Twitter](https://github.com/sferik/twitter), that uses this gem, we're receiving the bellow error:
![force_encoding](https://user-images.githubusercontent.com/173159/110676662-f6d13680-81b2-11eb-998b-5897a3181e47.png)

This would have happened on this [PR](https://github.com/httprb/http/pull/344) when the strings inside of gem have became frozen also, and the problem was solved making test strings unfrozen.

This PR proposes to make the Response class deal with frozen strings.