### PR TITLE
Handle connection timeouts in Features

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -68,9 +68,9 @@ module HTTP
 
       @state = :dirty
 
-      @connection ||= HTTP::Connection.new(req, options)
-
       begin
+        @connection ||= HTTP::Connection.new(req, options)
+
         unless @connection.failed_proxy_connect?
           @connection.send_request(req)
           @connection.read_headers!

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -310,6 +310,7 @@ RSpec.describe HTTP::Client do
           end
         end
       end
+
       it "is given a chance to wrap the Request" do
         feature_instance = feature_class.new
 
@@ -343,6 +344,19 @@ RSpec.describe HTTP::Client do
         expect(feature_instance.captured_error).to be_a(HTTP::TimeoutError)
         expect(feature_instance.captured_request.verb).to eq(:post)
         expect(feature_instance.captured_request.uri.to_s).to eq(sleep_url)
+      end
+
+      it "is given a chance to handle a connection timeout error" do
+        allow(TCPSocket).to receive(:open) { sleep 1 }
+        sleep_url = "#{dummy.endpoint}/sleep"
+        feature_instance = feature_class.new
+
+        expect do
+          client.use(:test_feature => feature_instance).
+            timeout(0.001).
+            request(:post, sleep_url)
+        end.to raise_error(HTTP::TimeoutError)
+        expect(feature_instance.captured_error).to be_a(HTTP::TimeoutError)
       end
     end
   end


### PR DESCRIPTION
The change from 609f07b3454bde2f48ca5e1589cda169f7a77187 allows Features to handle errors, but it isn’t a complete implementation, because while it does handle read/write timeouts, it does not work for connection timeouts.

This pull request resolves this by moving connection establishment to the exception-handling block introduced in that commit.