### PR TITLE
v5.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,19 @@
-## future is unwritten (master)
+## 5.0.0 (2021-05-12)
+
+* [#656](https://github.com/httprb/http/pull/656)
+  Handle connection timeouts in `Features`
+  ([@semenyukdmitry])
+
+* [#651](https://github.com/httprb/http/pull/651)
+  Replace `http-parser` with `llhttp`
+  ([@bryanp])
+
+* [#647](https://github.com/httprb/http/pull/647)
+  Add support for `MKCALENDAR` HTTP verb
+  ([@meanphil])
 
 * [#632](https://github.com/httprb/http/pull/632)
-  Respect the SSL context's verify_hostname value
+  Respect the SSL context's `verify_hostname` value
   ([@colemannugent])
 
 * [#625](https://github.com/httprb/http/pull/625)
@@ -9,7 +21,7 @@
   ([@LukaszMaslej])
 
 * [#599](https://github.com/httprb/http/pull/599)
-  Allow passing HTTP::FormData::{Multipart,UrlEncoded} object directly.
+  Allow passing `HTTP::FormData::{Multipart,UrlEncoded}` object directly.
   ([@ixti])
 
 * [#593](https://github.com/httprb/http/pull/593)
@@ -872,3 +884,6 @@ end
 [@antonvolkoff]: https://github.com/antonvolkoff
 [@LukaszMaslej]: https://github.com/LukaszMaslej
 [@colemannugent]: https://github.com/colemannugent
+[@semenyukdmitry]: https://github.com/semenyukdmitry
+[@bryanp]: https://github.com/bryanp
+[@meanphil]: https://github.com/meanphil

--- a/lib/http/version.rb
+++ b/lib/http/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HTTP
-  VERSION = "5.0.0.pre3"
+  VERSION = "5.0.0"
 end


### PR DESCRIPTION
* [#656](https://github.com/httprb/http/pull/656) Handle connection timeouts in `Features` ([@semenyukdmitry])
* [#651](https://github.com/httprb/http/pull/651) Replace `http-parser` with `llhttp` ([@bryanp])
* [#647](https://github.com/httprb/http/pull/647) Add support for `MKCALENDAR` HTTP verb ([@meanphil])
* [#632](https://github.com/httprb/http/pull/632) Respect the SSL context's `verify_hostname` value ([@colemannugent])
* [#625](https://github.com/httprb/http/pull/625) Fix inflator with empty responses ([@LukaszMaslej])
* [#599](https://github.com/httprb/http/pull/599) Allow passing `HTTP::FormData::{Multipart,UrlEncoded}` object directly ([@ixti])
* [#593](https://github.com/httprb/http/pull/593) [#592](https://github.com/httprb/http/issues/592) Support informational (1XX) responses. ([@ixti])
* [#590](https://github.com/httprb/http/pull/590) [#589](https://github.com/httprb/http/issues/589) Fix response headers paring. ([@Bonias])
* [#587](https://github.com/httprb/http/pull/587) [#585](https://github.com/httprb/http/issues/585) Fix redirections when server responds with multiple Location headers. ([@ixti])
* [#581](https://github.com/httprb/http/pull/581) [#582](https://github.com/httprb/http/issues/582) Add Ruby 2.7.x support. ([@janko])
* [#577](https://github.com/httprb/http/pull/577) Fix `Chainable#timeout` with frozen Hash. ([@antonvolkoff])
* [#576](https://github.com/httprb/http/pull/576) [#524](https://github.com/httprb/http/issues/524) Preserve header names casing. ([@joshuaflanagan])
* [#532](https://github.com/httprb/http/pull/532) Fix pipes support in request bodies. ([@ixti])
* [#530](https://github.com/httprb/http/pull/530) Improve header fields name/value validation. ([@Bonias])
* [#506](https://github.com/httprb/http/pull/506) [#521](https://github.com/httprb/http/issues/521) Skip auto-deflate when there is no body. ([@Bonias])
* [#489](https://github.com/httprb/http/pull/489) Fix HTTP parser. ([@ixti], [@fxposter])
* [#546](https://github.com/httprb/http/pull/546) **BREAKING CHANGE** Provide initiating `HTTP::Request` object on `HTTP::Response`. ([@joshuaflanagan])
* [#571](https://github.com/httprb/http/pull/571) Drop Ruby 2.3.x support. ([@ixti])

[@tarcieri]: https://github.com/tarcieri
[@zanker]: https://github.com/zanker
[@ixti]: https://github.com/ixti
[@Connorhd]: https://github.com/Connorhd
[@Asmod4n]: https://github.com/Asmod4n
[@pezra]: https://github.com/pezra
[@olegkovalenko]: https://github.com/olegkovalenko
[@mickm]: https://github.com/mickm
[@sferik]: https://github.com/sferik
[@nicoolas25]: https://github.com/nicoolas25
[@challengee]: https://github.com/challengee
[@hannesg]: https://github.com/hannesg
[@krainboltgreene]: https://github.com/krainboltgreene
[@hundredwatt]: https://github.com/hundredwatt
[@jwinter]: https://github.com/jwinter
[@nerdrew]: https://github.com/nerdrew
[@kylekyle]: https://github.com/kylekyle
[@smudge]: https://github.com/smudge
[@mwitek]: https://github.com/mwitek
[@tonyta]: https://github.com/tonyta
[@jhbabon]: https://github.com/jhbabon
[@britishtea]: https://github.com/britishtea
[@janko-m]: https://github.com/janko-m
[@Bonias]: https://github.com/Bonias
[@HoneyryderChuck]: https://github.com/HoneyryderChuck
[@marshall-lee]: https://github.com/marshall-lee
[@scarfacedeb]: https://github.com/scarfacedeb
[@mikegee]: https://github.com/mikegee
[@tycoon]: https://github.com/tycooon
[@paul]: https://github.com/paul
[@RickCSong]: https://github.com/RickCSong
[@fxposter]: https://github.com/fxposter
[@mamoonraja]: https://github.com/mamoonraja
[@joshuaflanagan]: https://github.com/joshuaflanagan
[@antonvolkoff]: https://github.com/antonvolkoff
[@LukaszMaslej]: https://github.com/LukaszMaslej
[@colemannugent]: https://github.com/colemannugent
[@semenyukdmitry]: https://github.com/semenyukdmitry
[@bryanp]: https://github.com/bryanp
[@meanphil]: https://github.com/meanphil