### PR TITLE
Bump llhttp-ffi to 0.3.0

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "addressable",    "~> 2.3"
   gem.add_runtime_dependency "http-cookie",    "~> 1.0"
   gem.add_runtime_dependency "http-form_data", "~> 2.2"
-  gem.add_runtime_dependency "llhttp-ffi",     "~> 0.0.1"
+  gem.add_runtime_dependency "llhttp-ffi",     "~> 0.3.0"
 
   gem.add_development_dependency "bundler", "~> 2.0"
 


### PR DESCRIPTION
Updates the `llhttp-ffi` dependency to `v0.3.0`. The only difference is that it now uses `lhttp v6.0.1`, the latest release.