### PR TITLE
CHANGES mentions dropped ruby 2.4.0 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,9 @@
   Drop Ruby 2.3.x support.
   ([@ixti])
 
+* [3ed0c31](https://github.com/httprb/http/commit/3ed0c318eab6a8c390654cda17bf6df9e963c7d6)
+  Drop Ruby 2.4.x support.
+
 
 ## 4.4.0 (2020-03-25)
 


### PR DESCRIPTION
Drop of ruby 2.3.0 was already mentioned in CHANGES.md.  Drop of 2.4.0 was not, but 2.4.0 is in fact dropped in http release 5.0.0, and it should also be mentioned in changelog.