### PR TITLE
feature: Restore HTTP::Response :uri option for backwards compatibility.

### DIFF
--- a/lib/http/features/auto_inflate.rb
+++ b/lib/http/features/auto_inflate.rb
@@ -21,8 +21,6 @@ module HTTP
           :request       => response.request
         }
 
-        options[:uri] = response.uri if response.uri
-
         Response.new(options)
       end
 

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -40,10 +40,11 @@ module HTTP
     # @option opts [HTTP::Connection] :connection
     # @option opts [String] :encoding Encoding to use when reading body
     # @option opts [String] :body
-    # @option opts [HTTP::Request] request
+    # @option opts [HTTP::Request] request The request this is in response to.
+    # @option opts [String] :uri (DEPRECATED) used to populate a missing request
     def initialize(opts)
       @version       = opts.fetch(:version)
-      @request       = opts.fetch(:request)
+      @request       = init_request(opts)
       @status        = HTTP::Response::Status.new(opts.fetch(:status))
       @headers       = HTTP::Headers.coerce(opts[:headers] || {})
       @proxy_headers = HTTP::Headers.coerce(opts[:proxy_headers] || {})
@@ -163,6 +164,23 @@ module HTTP
     # Inspect a response
     def inspect
       "#<#{self.class}/#{@version} #{code} #{reason} #{headers.to_h.inspect}>"
+    end
+
+    private
+
+    # Initialize an HTTP::Request from options.
+    #
+    # @return [HTTP::Request]
+    def init_request(opts)
+      raise ArgumentError, ":uri is for backwards compatibilty and conflicts with :request" \
+        if opts[:request] && opts[:uri]
+
+      # For backwards compatibilty
+      if opts[:uri]
+        HTTP::Request.new(:uri => opts[:uri], :verb => :get)
+      else
+        opts.fetch(:request)
+      end
     end
   end
 end

--- a/spec/lib/http/features/auto_inflate_spec.rb
+++ b/spec/lib/http/features/auto_inflate_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe HTTP::Features::AutoInflate do
           :status     => 200,
           :headers    => {:content_encoding => "gzip"},
           :connection => connection,
-          :uri        => "https://example.com",
           :request    => HTTP::Request.new(:verb => :get, :uri => "https://example.com")
         )
       end

--- a/spec/lib/http/features/instrumentation_spec.rb
+++ b/spec/lib/http/features/instrumentation_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe HTTP::Features::Instrumentation do
     let(:response) do
       HTTP::Response.new(
         :version => "1.1",
-        :uri     => "https://example.com",
         :status  => 200,
         :headers => {:content_type => "application/json"},
         :body    => '{"success": true}',

--- a/spec/lib/http/features/logging_spec.rb
+++ b/spec/lib/http/features/logging_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe HTTP::Features::Logging do
     let(:response) do
       HTTP::Response.new(
         :version => "1.1",
-        :uri     => "https://example.com",
         :status  => 200,
         :headers => {:content_type => "application/json"},
         :body    => '{"success": true}',

--- a/spec/lib/http/response_spec.rb
+++ b/spec/lib/http/response_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe HTTP::Response do
   let(:body)          { "Hello world!" }
   let(:uri)           { "http://example.com/" }
   let(:headers)       { {} }
+  let(:request)       { HTTP::Request.new(:verb => :get, :uri => uri) }
 
   subject(:response) do
     HTTP::Response.new(
@@ -11,8 +12,7 @@ RSpec.describe HTTP::Response do
       :version => "1.1",
       :headers => headers,
       :body    => body,
-      :uri     => uri,
-      :request => HTTP::Request.new(:verb => :get, :uri => "http://example.com")
+      :request => request
     )
   end
 
@@ -167,7 +167,7 @@ RSpec.describe HTTP::Response do
         :version    => "1.1",
         :status     => 200,
         :connection => connection,
-        :request    => HTTP::Request.new(:verb => :get, :uri => "http://example.com")
+        :request    => request
       )
     end
 
@@ -183,5 +183,44 @@ RSpec.describe HTTP::Response do
       it { is_expected.to be_chunked }
     end
     it { is_expected.not_to be_chunked }
+  end
+
+  describe "backwards compatibilty with :uri" do
+    context "with no :verb" do
+      subject(:response) do
+        HTTP::Response.new(
+          :status  => 200,
+          :version => "1.1",
+          :headers => headers,
+          :body    => body,
+          :uri     => uri
+        )
+      end
+
+      it "defaults the uri to :uri" do
+        expect(response.request.uri.to_s).to eq uri
+      end
+
+      it "defaults to the verb to :get" do
+        expect(response.request.verb).to eq :get
+      end
+    end
+
+    context "with both a :request and :uri" do
+      subject(:response) do
+        HTTP::Response.new(
+          :status  => 200,
+          :version => "1.1",
+          :headers => headers,
+          :body    => body,
+          :uri     => uri,
+          :request => request
+        )
+      end
+
+      it "raises ArgumentError" do
+        expect { response }.to raise_error(ArgumentError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This should allow folks to update to 5.x without breaking code, in my case
test factories, which make HTTP::Responses.

If nothing else, the current code has the potential for `response.uri` and `response.request.uri` to be different and that seems Bad.

* Put :uri back, but its deprecated. Remove it in 6.x?
* :uri and :request now conflict to avoid having uri being one thing and request.uri another.
    * Could allow it if uri and request.uri.to_s match?
    * Is supplying both useful for forward compatibility?
* Remove redundant internal uses of uri.