### PR TITLE
Use features on redirected requests (4.x)

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -32,7 +32,7 @@ module HTTP
       return res unless opts.follow
 
       Redirector.new(opts.follow).perform(req, res) do |request|
-        perform(request, opts)
+        perform(wrap_request(request, opts), opts)
       end
     end
 
@@ -52,9 +52,7 @@ module HTTP
         :body           => body
       )
 
-      opts.features.inject(req) do |request, (_name, feature)|
-        feature.wrap_request(request)
-      end
+      wrap_request(req, opts)
     end
 
     # @!method persistent?
@@ -105,6 +103,12 @@ module HTTP
     end
 
     private
+
+    def wrap_request(req, opts)
+      opts.features.inject(req) do |request, (_name, feature)|
+        feature.wrap_request(request)
+      end
+    end
 
     # Verify our request isn't going to be made against another URI
     def verify_connection!(uri)


### PR DESCRIPTION
When following redirects, features are not used for subsequent requests.

This makes it impossible to use automatic deflation after a redirect or to log and instrument redirected requests.

Wrap requests with configured features when following redirects.