### PR TITLE
Don't set Content-Length for GET, HEAD, DELETE, or CONNECT requests without a BODY

### DIFF
--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -47,7 +47,11 @@ module HTTP
       # Adds the headers to the header array for the given request body we are working
       # with
       def add_body_type_headers
-        return if @headers[Headers::CONTENT_LENGTH] || chunked?
+        return if @headers[Headers::CONTENT_LENGTH] || chunked? || (
+          @body.source.nil? && %w[GET HEAD DELETE CONNECT].any? do |method|
+            @request_header[0].start_with?("#{method} ")
+          end
+        )
 
         @request_header << "#{Headers::CONTENT_LENGTH}: #{@body.size}"
       end

--- a/spec/lib/http/request/writer_spec.rb
+++ b/spec/lib/http/request/writer_spec.rb
@@ -47,8 +47,19 @@ RSpec.describe HTTP::Request::Writer do
       end
     end
 
-    context "when body is empty" do
+    context "when body is not set" do
       let(:body) { HTTP::Request::Body.new(nil) }
+
+      it "doesn't write anything to the socket and doesn't set Content-Length" do
+        writer.stream
+        expect(io.string).to eq [
+          "#{headerstart}\r\n\r\n"
+        ].join
+      end
+    end
+
+    context "when body is empty" do
+      let(:body) { HTTP::Request::Body.new("") }
 
       it "doesn't write anything to the socket and sets Content-Length" do
         writer.stream


### PR DESCRIPTION
The HTTP spec says (https://tools.ietf.org/html/rfc7230#section-3.3.2):

> A user agent SHOULD NOT send a Content-Length header field when the request message does not contain a payload body and the method semantics do not anticipate such a body

Fixes https://github.com/httprb/http/issues/487.

This is my first time writing Ruby so hopefully the code isn't too bad :sweat_smile: happy to make changes.