### PR TITLE
Correctly reset the parser

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "addressable",    "~> 2.8"
   gem.add_runtime_dependency "http-cookie",    "~> 1.0"
   gem.add_runtime_dependency "http-form_data", "~> 2.2"
-  gem.add_runtime_dependency "llhttp-ffi",     "~> 0.3.0"
+  gem.add_runtime_dependency "llhttp-ffi",     "~> 0.4.0"
 
   gem.add_development_dependency "bundler", "~> 2.0"
 

--- a/lib/http/response/parser.rb
+++ b/lib/http/response/parser.rb
@@ -15,7 +15,7 @@ module HTTP
       end
 
       def reset
-        @parser.finish
+        @parser.reset
         @handler.reset
         @header_finished = false
         @message_finished = false


### PR DESCRIPTION
Resolves https://github.com/httprb/http/issues/685.

```
irb(main):004:0> HTTP.via('127.0.0.1', 8080).get('https://httpbin.org/get')
=> #<HTTP::Response/1.1 200 OK {"Date"=>"Thu, 09 Sep 2021 22:27:04 GMT", "Content-Type"=>"application/json", "Content-Length"=>"235", "Connection"=>"close", "Server"=>"gunicorn/19.9.0", "Access-Control-Allow-Origin"=>"*", "Access-Control-Allow-Credentials"=>"true"}>
```

I propose we include this as part of a 0.5.2 release.