### PR TITLE
Remove note about 5.x only being a dev branch now that its been released

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@
 
 [Documentation]
 
-_NOTE: This is the 5.x **development** branch.  For the 4.x **stable** branch, please see:_
-
-https://github.com/httprb/http/tree/4-x-stable
-
 ## About
 
 HTTP (The Gem! a.k.a. http.rb) is an easy-to-use client library for making requests


### PR DESCRIPTION
Small update to the README to remove note about 4.x now that 5.x is the stable branch. 