### PR TITLE
Pin to rubocop v1.21; fix offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :test do
 
   gem "backports"
 
-  gem "rubocop"
+  gem "rubocop", "~> 1.21"
   gem "rubocop-performance"
   gem "rubocop-rake"
   gem "rubocop-rspec"

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -61,7 +61,7 @@ module HTTP
       def join_headers
         # join the headers array with crlfs, stick two on the end because
         # that ends the request header
-        @request_header.join(CRLF) + CRLF * 2
+        @request_header.join(CRLF) + (CRLF * 2)
       end
 
       # Writes HTTP request data into the socket.

--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -53,11 +53,11 @@ module HTTP
         begin
           @socket.connect_nonblock
         rescue IO::WaitReadable
-          IO.select([@socket], nil, nil, @time_left)
+          @socket.wait_readable(@time_left)
           log_time
           retry
         rescue IO::WaitWritable
-          IO.select(nil, [@socket], nil, @time_left)
+          @socket.wait_writable(@time_left)
           log_time
           retry
         end

--- a/spec/lib/http/request/body_spec.rb
+++ b/spec/lib/http/request/body_spec.rb
@@ -118,10 +118,10 @@ RSpec.describe HTTP::Request::Body do
     end
 
     context "when body is a non-Enumerable IO" do
-      let(:body) { FakeIO.new("a" * 16 * 1024 + "b" * 10 * 1024) }
+      let(:body) { FakeIO.new(("a" * 16 * 1024) + ("b" * 10 * 1024)) }
 
       it "yields chunks of content" do
-        expect(chunks.inject("", :+)).to eq "a" * 16 * 1024 + "b" * 10 * 1024
+        expect(chunks.inject("", :+)).to eq ("a" * 16 * 1024) + ("b" * 10 * 1024)
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe HTTP::Request::Body do
     end
 
     context "when body is an Enumerable IO" do
-      let(:data) { "a" * 16 * 1024 + "b" * 10 * 1024 }
+      let(:data) { ("a" * 16 * 1024) + ("b" * 10 * 1024) }
       let(:body) { StringIO.new data }
 
       it "yields chunks of content" do


### PR DESCRIPTION
It seems we didn't have the rubocop version pinned before, and the latest version added new lints which we are failing.

The failures have been autocorrected.