### PR TITLE
v5.0.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 5.0.4 (2021-10-07)
+
+* [#698](https://github.com/httprb/http/pull/698)
+  Fix `HTTP::Timeout::Global#connect_ssl`.
+  ([@tarcieri])
+
 ## 5.0.3 (2021-10-06)
 
 * [#695](https://github.com/httprb/http/pull/695)

--- a/lib/http/version.rb
+++ b/lib/http/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HTTP
-  VERSION = "5.0.3"
+  VERSION = "5.0.4"
 end


### PR DESCRIPTION
* [#698](https://github.com/httprb/http/pull/698) Fix `HTTP::Timeout::Global#connect_ssl` (@tarcieri)