### PR TITLE
Distinguish connection timeouts

### DIFF
--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -19,6 +19,9 @@ module HTTP
   # Generic Timeout error
   class TimeoutError < Error; end
 
+  # Timeout when first establishing the conncetion
+  class ConnectionTimeoutError < TimeoutError; end
+
   # Header value is of unexpected format (similar to Net::HTTPHeaderSyntaxError)
   class HeaderError < Error; end
 end

--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -20,7 +20,7 @@ module HTTP
   class TimeoutError < Error; end
 
   # Timeout when first establishing the conncetion
-  class ConnectionTimeoutError < TimeoutError; end
+  class ConnectTimeoutError < TimeoutError; end
 
   # Header value is of unexpected format (similar to Net::HTTPHeaderSyntaxError)
   class HeaderError < Error; end

--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -21,7 +21,7 @@ module HTTP
 
       def connect(socket_class, host, port, nodelay = false)
         reset_timer
-        ::Timeout.timeout(@time_left, ConnectionTimeoutError) do
+        ::Timeout.timeout(@time_left, ConnectTimeoutError) do
           @socket = socket_class.open(host, port)
           @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1) if nodelay
         end

--- a/lib/http/timeout/global.rb
+++ b/lib/http/timeout/global.rb
@@ -21,7 +21,7 @@ module HTTP
 
       def connect(socket_class, host, port, nodelay = false)
         reset_timer
-        ::Timeout.timeout(@time_left, TimeoutError) do
+        ::Timeout.timeout(@time_left, ConnectionTimeoutError) do
           @socket = socket_class.open(host, port)
           @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1) if nodelay
         end

--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -20,7 +20,7 @@ module HTTP
       end
 
       def connect(socket_class, host, port, nodelay = false)
-        ::Timeout.timeout(@connect_timeout, TimeoutError) do
+        ::Timeout.timeout(@connect_timeout, ConnectionTimeoutError) do
           @socket = socket_class.open(host, port)
           @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1) if nodelay
         end

--- a/lib/http/timeout/per_operation.rb
+++ b/lib/http/timeout/per_operation.rb
@@ -20,7 +20,7 @@ module HTTP
       end
 
       def connect(socket_class, host, port, nodelay = false)
-        ::Timeout.timeout(@connect_timeout, ConnectionTimeoutError) do
+        ::Timeout.timeout(@connect_timeout, ConnectTimeoutError) do
           @socket = socket_class.open(host, port)
           @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1) if nodelay
         end

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -389,8 +389,8 @@ RSpec.describe HTTP::Client do
           client.use(:test_feature => feature_instance).
             timeout(0.001).
             request(:post, sleep_url)
-        end.to raise_error(HTTP::ConnectionTimeoutError)
-        expect(feature_instance.captured_error).to be_a(HTTP::ConnectionTimeoutError)
+        end.to raise_error(HTTP::ConnectTimeoutError)
+        expect(feature_instance.captured_error).to be_a(HTTP::ConnectTimeoutError)
       end
     end
   end

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -389,8 +389,8 @@ RSpec.describe HTTP::Client do
           client.use(:test_feature => feature_instance).
             timeout(0.001).
             request(:post, sleep_url)
-        end.to raise_error(HTTP::TimeoutError)
-        expect(feature_instance.captured_error).to be_a(HTTP::TimeoutError)
+        end.to raise_error(HTTP::ConnectionTimeoutError)
+        expect(feature_instance.captured_error).to be_a(HTTP::ConnectionTimeoutError)
       end
     end
   end

--- a/spec/support/http_handling_shared.rb
+++ b/spec/support/http_handling_shared.rb
@@ -77,7 +77,7 @@ RSpec.shared_context "HTTP handling" do
         sleep 1.25
       end
 
-      expect { response }.to raise_error(HTTP::TimeoutError, /execution/)
+      expect { response }.to raise_error(HTTP::ConnectionTimeoutError, /execution/)
     end
 
     it "errors if reading takes too long" do

--- a/spec/support/http_handling_shared.rb
+++ b/spec/support/http_handling_shared.rb
@@ -77,7 +77,7 @@ RSpec.shared_context "HTTP handling" do
         sleep 1.25
       end
 
-      expect { response }.to raise_error(HTTP::ConnectionTimeoutError, /execution/)
+      expect { response }.to raise_error(HTTP::ConnectTimeoutError, /execution/)
     end
 
     it "errors if reading takes too long" do


### PR DESCRIPTION
HTTP.rb offers us a way of configuring open timeouts, but there is no way to tell which timeout is what from the caller's point of view.

In some scenarios such as systems prone to occasional network intermittencies, singling out a short connection timeout to retry specifically for that case is often desirable.  A catch-all retry strategy like we have today makes it hard to decide when to attempt a cheap and quick network intermittence retry from a long, target endpoint-health related write or read retry. 

I'm proposing we introduce `ConnectionTimeoutError` as a subclass of `TimeoutError` so it becomes possible for the user to selectively catch open-time specific timeouts while maintaining compatibility with catch-all code currently using `TimeoutError`.