### PR TITLE
Set default encoding to UTF-8 for json

### DIFF
--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -53,7 +53,7 @@ module HTTP
         @body = opts.fetch(:body)
       else
         connection = opts.fetch(:connection)
-        encoding   = fetch_or_default_encoding(opts)
+        encoding = opts[:encoding] || charset || default_encoding
 
         @body = Response::Body.new(connection, :encoding => encoding)
       end
@@ -168,15 +168,9 @@ module HTTP
 
     private
 
-    def fetch_or_default_encoding(opts)
-      return opts[:encoding] if opts[:encoding]
-      return charset if charset
-
-      if mime_type == "application/json"
-        Encoding::UTF_8
-      else
-        Encoding::BINARY
-      end
+    def default_encoding
+      return Encoding::UTF_8 if mime_type == "application/json"
+      Encoding::BINARY
     end
 
     # Initialize an HTTP::Request from options.

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -53,7 +53,15 @@ module HTTP
         @body = opts.fetch(:body)
       else
         connection = opts.fetch(:connection)
-        encoding   = opts[:encoding] || charset || Encoding::BINARY
+        encoding   = opts[:encoding] || charset
+
+        if encoding.nil?
+          encoding = if mime_type == "application/json"
+                       Encoding::UTF_8
+                     else
+                       Encoding::BINARY
+                     end
+        end
 
         @body = Response::Body.new(connection, :encoding => encoding)
       end

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -53,15 +53,7 @@ module HTTP
         @body = opts.fetch(:body)
       else
         connection = opts.fetch(:connection)
-        encoding   = opts[:encoding] || charset
-
-        if encoding.nil?
-          encoding = if mime_type == "application/json"
-                       Encoding::UTF_8
-                     else
-                       Encoding::BINARY
-                     end
-        end
+        encoding   = fetch_or_default_encoding(opts)
 
         @body = Response::Body.new(connection, :encoding => encoding)
       end
@@ -175,6 +167,17 @@ module HTTP
     end
 
     private
+
+    def fetch_or_default_encoding(opts)
+      return opts[:encoding] if opts[:encoding]
+      return charset if charset
+
+      if mime_type == "application/json"
+        Encoding::UTF_8
+      else
+        Encoding::BINARY
+      end
+    end
 
     # Initialize an HTTP::Request from options.
     #

--- a/spec/lib/http/response_spec.rb
+++ b/spec/lib/http/response_spec.rb
@@ -223,4 +223,40 @@ RSpec.describe HTTP::Response do
       end
     end
   end
+
+  describe "#body" do
+    let(:connection) { double(:sequence_id => 0) }
+    let(:chunks)     { ["Hello, ", "World!"] }
+
+    subject(:response) do
+      HTTP::Response.new(
+        :status     => 200,
+        :version    => "1.1",
+        :headers    => headers,
+        :request    => request,
+        :connection => connection
+      )
+    end
+
+    before do
+      allow(connection).to receive(:readpartial) { chunks.shift }
+      allow(connection).to receive(:body_completed?) { chunks.empty? }
+    end
+
+    context "with no Content-Type" do
+      let(:headers) { {} }
+
+      it "returns a body with default binary encoding" do
+        expect(response.body.to_s.encoding).to eq Encoding::BINARY
+      end
+    end
+
+    context "with Content-Type: application/json" do
+      let(:headers) { {"Content-Type" => "application/json"} }
+
+      it "returns a body with a default UTF_8 encoding" do
+        expect(response.body.to_s.encoding).to eq Encoding::UTF_8
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR changes the default encoding for response with the type `application/json` to be UTF-8 by default, instead of binary.

Implements https://github.com/httprb/http/issues/714.