### PR TITLE
Explicitly require cgi in client_spec.rb

### DIFF
--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 # frozen_string_literal: true
 
+require "cgi"
 require "support/http_handling_shared"
 require "support/dummy_server"
 require "support/ssl_helper"


### PR DESCRIPTION
I am observing the same behavior in this test as documented in https://github.com/pact-foundation/pact-support/pull/29; applying the same fix also fixes it here.