### PR TITLE
Add on_redirect callback.

### DIFF
--- a/lib/http/redirector.rb
+++ b/lib/http/redirector.rb
@@ -40,8 +40,9 @@ module HTTP
     # @option opts [Boolean] :strict (true) redirector hops policy
     # @option opts [#to_i] :max_hops (5) maximum allowed amount of hops
     def initialize(opts = {})
-      @strict   = opts.fetch(:strict, true)
-      @max_hops = opts.fetch(:max_hops, 5).to_i
+      @strict      = opts.fetch(:strict, true)
+      @max_hops    = opts.fetch(:max_hops, 5).to_i
+      @on_redirect = opts.fetch(:on_redirect, nil)
     end
 
     # Follows redirects until non-redirect response found
@@ -65,6 +66,7 @@ module HTTP
         unless cookie_jar.empty?
           @request.headers.set(Headers::COOKIE, cookie_jar.cookies.map { |c| "#{c.name}=#{c.value}" }.join("; "))
         end
+        @on_redirect.call @response, @request if @on_redirect.respond_to?(:call)
         @response = yield @request
         collect_cookies_from_response
       end

--- a/spec/lib/http/redirector_spec.rb
+++ b/spec/lib/http/redirector_spec.rb
@@ -148,6 +148,32 @@ RSpec.describe HTTP::Redirector do
       expect(cookies["deleted"]).to eq nil
     end
 
+    context "with on_redirect callback" do
+      let(:options) do
+        {
+          :on_redirect => proc do |response, location|
+            @redirect_response = response
+            @redirect_location = location
+          end
+        }
+      end
+
+      it "calls on_redirect" do
+        req = HTTP::Request.new :verb => :head, :uri => "http://example.com"
+        hops = [
+          redirect_response(301, "http://example.com/1"),
+          redirect_response(301, "http://example.com/2"),
+          simple_response(200, "foo")
+        ]
+
+        redirector.perform(req, hops.shift) do |prev_req, _|
+          expect(@redirect_location.uri.to_s).to eq prev_req.uri.to_s
+          expect(@redirect_response.code).to eq 301
+          hops.shift
+        end
+      end
+    end
+
     context "following 300 redirect" do
       context "with strict mode" do
         let(:options) { {:strict => true} }


### PR DESCRIPTION
Hello,

This adds an `on_redirect` callback that can be passed to `.follow`. For example:

```ruby
permanent_redirects = []
HTTP.follow(
  max_hops: 4, 
  on_redirect: proc do |from, to|
    permanent_redirects.push({ from: from.uri.to_s, to: to.uri.to_s }) if [301, 308].include?(from.status.code)
  end
).get("…")
```

I found this feature to be useful while trying to come up with a redirect caching system.

Thanks!
