### PR TITLE
raise HTTP::Request::InvalidURIError for wrong url's

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -154,6 +154,8 @@ module HTTP
       uri.path = "/" if uri.path.empty?
 
       uri
+    rescue Addressable::URI::InvalidURIError => e
+      raise HTTP::Request::InvalidURIError, e.message
     end
 
     # Creates request headers with cookies (if any) merged in

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -23,6 +23,9 @@ module HTTP
     # The scheme of given URI was not understood
     class UnsupportedSchemeError < RequestError; end
 
+    # Provided url is missing or wrong
+    class InvalidURIError < RequestError; end
+
     # Default User-Agent header value
     USER_AGENT = "http.rb/#{HTTP::VERSION}"
 
@@ -90,6 +93,7 @@ module HTTP
       @uri    = @uri_normalizer.call(opts.fetch(:uri))
       @scheme = @uri.scheme.to_s.downcase.to_sym if @uri.scheme
 
+      raise(InvalidURIError, "empty uri provided") if @uri.host.nil?
       raise(UnsupportedMethodError, "unknown method: #{verb}") unless METHODS.include?(@verb)
       raise(UnsupportedSchemeError, "unknown scheme: #{scheme}") unless SCHEMES.include?(@scheme)
 

--- a/spec/lib/http/request_spec.rb
+++ b/spec/lib/http/request_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe HTTP::Request do
 
   it "requires URI to have scheme part" do
     expect { HTTP::Request.new(:verb => :get, :uri => "example.com/") }.to \
-      raise_error(HTTP::Request::UnsupportedSchemeError)
+      raise_error(HTTP::Request::InvalidURIError)
   end
 
   it "provides a #scheme accessor" do

--- a/spec/lib/http_spec.rb
+++ b/spec/lib/http_spec.rb
@@ -391,6 +391,23 @@ RSpec.describe HTTP do
     end
   end
 
+  describe "gives a proper error for invalid URLs" do
+    it "throws InvalidURIError on nil" do
+      expect { HTTP.get(nil) }.to raise_error(HTTP::Request::InvalidURIError)
+      expect { HTTP.post(nil, :body => "Hello") }.to raise_error(HTTP::Request::InvalidURIError)
+    end
+
+    it "throws InvalidURIError on empty" do
+      expect { HTTP.get("") }.to raise_error(HTTP::Request::InvalidURIError)
+      expect { HTTP.post("", :body => "Hello") }.to raise_error(HTTP::Request::InvalidURIError)
+    end
+
+    it "throws InvalidURIError for incorrect url" do
+      expect { HTTP.get("/") }.to raise_error(HTTP::Request::InvalidURIError)
+      expect { HTTP.get(":") }.to raise_error(HTTP::Request::InvalidURIError)
+    end
+  end
+
   describe ".use" do
     it "turns on given feature" do
       client = HTTP.use :auto_deflate


### PR DESCRIPTION
Really enjoy using your gem, so decided to study internal of it better. 

is there any better way to understand internals, when contributing to gem directly? I guess, not.

This PR addressed an issue that is assigned for 5.0 milestone

closes #565