### PR TITLE
Fixed incorrect link in CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,7 +54,7 @@
   Use features on redirected requests.
   ([@nomis])
 
-* [#678](https://github.com/schwern)
+* [#678](https://github.com/httprb/http/pull/678)
   Restore `HTTP::Response` `:uri` option for backwards compatibility.
   ([@schwern])
 


### PR DESCRIPTION
Thanks everyone to their contributions to this gem. Really appreciate all the effort put in.

I've been in the middle of upgrading from 4.x to 5.x and I noticed an incorrect link in the change log. Fixed so it points to the correct link