### PR TITLE
Add `Connection#finished_request?`

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -132,7 +132,7 @@ module HTTP
       @pending_request  = false
     end
 
-    def finished?
+    def finished_request?
       !@pending_request && !@pending_response
     end
 

--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -132,6 +132,10 @@ module HTTP
       @pending_request  = false
     end
 
+    def finished?
+      !@pending_request && !@pending_response
+    end
+
     # Whether we're keeping the conn alive
     # @return [Boolean]
     def keep_alive?

--- a/spec/lib/http/connection_spec.rb
+++ b/spec/lib/http/connection_spec.rb
@@ -58,11 +58,11 @@ RSpec.describe HTTP::Connection do
       connection.read_headers!
       buffer = String.new
       while (s = connection.readpartial(3))
-        expect(connection.finished?).to be false if s != ""
+        expect(connection.finished_request?).to be false if s != ""
         buffer << s
       end
       expect(buffer).to eq "1234567890"
-      expect(connection.finished?).to be true
+      expect(connection.finished_request?).to be true
     end
   end
 end

--- a/spec/lib/http/connection_spec.rb
+++ b/spec/lib/http/connection_spec.rb
@@ -58,9 +58,11 @@ RSpec.describe HTTP::Connection do
       connection.read_headers!
       buffer = String.new
       while (s = connection.readpartial(3))
+        expect(connection.finished?).to be false if s != ""
         buffer << s
       end
       expect(buffer).to eq "1234567890"
+      expect(connection.finished?).to be true
     end
   end
 end


### PR DESCRIPTION
When using persistent connections there is no easy way to check if the entire body of the previous request has been consumed before sending a new request, e.g. if an exception was raised while reading the body.

Add `Connection#finished?` which does the same check as the guards in `Connection#send_request`.

https://github.com/httprb/http/blob/32a2ae68a1650d267f0687381d58880cf1b60315/lib/http/connection.rb#L69-L76