### PR TITLE
Bump llhttp-ffi (0.5.0)

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "addressable",    "~> 2.8"
   gem.add_runtime_dependency "http-cookie",    "~> 1.0"
   gem.add_runtime_dependency "http-form_data", "~> 2.2"
-  gem.add_runtime_dependency "llhttp-ffi",     "~> 0.4.0"
+  gem.add_runtime_dependency "llhttp-ffi",     "~> 0.5.0"
 
   gem.add_development_dependency "bundler", "~> 2.0"
 


### PR DESCRIPTION
Updates the `llhttp-ffi` dependency to `v0.5.0`. The only difference is that it now uses `lhttp v8.1.0`, the latest release.