### PR TITLE
Downcase Content-Type charset name

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -184,7 +184,7 @@ module HTTP
         form
       when opts.json
         body = MimeType[:json].encode opts.json
-        headers[Headers::CONTENT_TYPE] ||= "application/json; charset=#{body.encoding.name}"
+        headers[Headers::CONTENT_TYPE] ||= "application/json; charset=#{body.encoding.name.downcase}"
         body
       end
     end

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -261,6 +261,7 @@ RSpec.describe HTTP::Client do
 
       expect(HTTP::Request).to receive(:new) do |opts|
         expect(opts[:body]).to eq '{"foo":"bar"}'
+        expect(opts[:headers]["Content-Type"]).to eq "application/json; charset=utf-8"
       end
 
       client.get("http://example.com/", :json => {:foo => :bar})


### PR DESCRIPTION
Ran into an issue making requests to a server I don't control (Microsoft ASP.NET) where it was giving me errors POSTing JSON with `HTTP.post(path, json: {whatever})`. 

This header works: `Content-Type: application/json; charset=utf-8`
This did not: `Content-Type: application/json; charset=UTF-8`

HTTP.rb uses Ruby `String#encoding.name`, which returns "UTF" in all caps, which is causing the `charset=UTF-8`.

[MDN says "Case insensitive, lowercase preferred"](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type), so I just downcased the encoding name, and added a test.