### PR TITLE
Add support for the `PURGE` HTTP method.

### DIFF
--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -49,7 +49,10 @@ module HTTP
       :search,
 
       # RFC 4791: Calendaring Extensions to WebDAV -- CalDAV
-      :mkcalendar
+      :mkcalendar,
+
+      # Implemented by several caching servers, like Squid, Varnish or Fastly
+      :purge
     ].freeze
 
     # Allowed schemes


### PR DESCRIPTION
This method is not defined in an RFC, but the HTTP RFC allows custom methods to be defined.

The `PURGE` method is often used in HTTP caching servers, for example:
- [Squid](https://wiki.squid-cache.org/SquidFaq/OperatingSquid#how-can-i-purge-an-object-from-my-cache)
- [Varnish](https://varnish-cache.org/docs/4.0/users-guide/purging.html)
- [Fastly](https://developer.fastly.com/learning/concepts/purging/#single-purge)