### PR TITLE
Add `base64` to runtime dependency

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.6"
 
   gem.add_runtime_dependency "addressable",    "~> 2.8"
+  gem.add_runtime_dependency "base64",         "~> 0.1"
   gem.add_runtime_dependency "http-cookie",    "~> 1.0"
   gem.add_runtime_dependency "http-form_data", "~> 2.2"
   gem.add_runtime_dependency "llhttp-ffi",     "~> 0.5.0"


### PR DESCRIPTION
This PR adds `base64` to runtime dependency to suppress the following Ruby 3.3's warning:

```console
$ ruby -wve 'require "http"'
ruby 3.3.0dev (2023-08-14T15:48:39Z master 52837fcec2) [x86_64-darwin22]
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/http-5.1.1/lib/http/chainable.rb:3:
warning: base64 which will be not part of the default gems since Ruby 3.4.0
```

cf: https://github.com/rails/rails/pull/48907