### PR TITLE
fix: close sockets on connection initialize timeout

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -46,6 +46,9 @@ module HTTP
       reset_timer
     rescue IOError, SocketError, SystemCallError => e
       raise ConnectionError, "failed to connect: #{e}", e.backtrace
+    rescue TimeoutError
+      close
+      raise
     end
 
     # @see (HTTP::Response::Parser#status_code)
@@ -126,7 +129,7 @@ module HTTP
     # Close the connection
     # @return [void]
     def close
-      @socket.close unless @socket.closed?
+      @socket.close unless @socket&.closed?
 
       @pending_response = false
       @pending_request  = false

--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
 
-require "forwardable"
 require "io/wait"
 
 module HTTP
   module Timeout
     class Null
-      extend Forwardable
-
-      def_delegators :@socket, :close, :closed?
-
       attr_reader :options, :socket
 
       def initialize(options = {})
@@ -25,6 +20,14 @@ module HTTP
       # Starts a SSL connection on a socket
       def connect_ssl
         @socket.connect
+      end
+
+      def close
+        @socket&.close
+      end
+
+      def closed?
+        @socket&.closed?
       end
 
       # Configures the SSL connection and starts the connection


### PR DESCRIPTION
When timeouts are set on the client, there is potential for a resource leak when timeouts occur during connection initialization.

When timeout errors are thrown during connection initialization, the connection object itself is not created (nil) and the [client](https://github.com/httprb/http/blob/main/lib/http/client.rb#L70) won't be able to properly close the connection. 

This causes the created socket to stay in either an ESTABLISHED or CLOSE_WAIT state, while the client no longer has a reference to it, effectively causing a leak.

Steps to repro:

In the client:
```ruby
# irb or rails c
client = HTTP.timeout(5)

client.get("https://www.example.org").body.to_s # or use 240.0.0.0
client.get("https://www.example.org").body.to_s
client.get("https://www.example.org").body.to_s
```

Simultaneously:
1. Set up a mitm to intercept example.org, and add network conditioning to make the request very slow. Or you can use a black hole IP such as 240.0.0.0
2. Check the sockets opened by the ruby process:
```
watch -n 1 "lsof -i -P | grep PROCESS_PID" # replace PROCESS_PID with the rails process pid
```
You'll notice that sockets will stay in ESTABLISHED or CLOSE_WAIT as you make more and more requests that time out.

```
ruby    28497 rpeng   21u  IPv4 43444771      0t0  TCP f6eb5410737c:57558->93.184.216.34:443 (CLOSE_WAIT)
ruby    28497 rpeng   23u  IPv4 43449275      0t0  TCP f6eb5410737c:56876->93.184.216.34:443 (CLOSE_WAIT)
ruby    28497 rpeng   24u  IPv4 43452649      0t0  TCP f6eb5410737c:34242->93.184.216.34:443 (ESTABLISHED)
ruby    28497 rpeng   25u  IPv4 43458906      0t0  TCP f6eb5410737c:55366->93.184.216.34:443 (ESTABLISHED)
ruby    28497 rpeng   26u  IPv4 43461133      0t0  TCP f6eb5410737c:37510->93.184.216.34:443 (ESTABLISHED)
```

The fix ensures that a socket is closed if any timeouts happen during initialization, though I suspect we could make this even more stringent (e.g. on any StandardError, we ensure that we send @socket.close if a socket exists and is open)
