### PR TITLE
Prevent CRLF injection due to broken URL normalizer

### DIFF
--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -169,10 +169,12 @@ module HTTP
     def headline
       request_uri =
         if using_proxy? && !uri.https?
-          uri.omit(:fragment)
+          uri.omit(:fragment).to_s
         else
-          uri.request_uri
+          uri.request_uri.to_s
         end
+
+      raise RequestError, "Invalid request URI: #{request_uri.inspect}" if request_uri.match?(/\s/)
 
       "#{verb.to_s.upcase} #{request_uri} HTTP/#{version}"
     end
@@ -230,7 +232,11 @@ module HTTP
 
     # @return [String] Default host (with port if needed) header value.
     def default_host_header_value
-      PORTS[@scheme] == port ? host : "#{host}:#{port}"
+      value = PORTS[@scheme] == port ? host : "#{host}:#{port}"
+
+      raise RequestError, "Invalid host: #{value.inspect}" if value.match?(/\s/)
+
+      value
     end
 
     def prepare_body(body)

--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -169,10 +169,10 @@ module HTTP
     def headline
       request_uri =
         if using_proxy? && !uri.https?
-          uri.omit(:fragment).to_s
+          uri.omit(:fragment)
         else
-          uri.request_uri.to_s
-        end
+          uri.request_uri
+        end.to_s
 
       raise RequestError, "Invalid request URI: #{request_uri.inspect}" if request_uri.match?(/\s/)
 

--- a/spec/support/dummy_server/servlet.rb
+++ b/spec/support/dummy_server/servlet.rb
@@ -149,7 +149,7 @@ class DummyServer < WEBrick::HTTPServer
       res.body   = req.body
     end
 
-    get "/hello world" do |_req, res|
+    get "/héllö-wörld".b do |_req, res|
       res.status = 200
       res.body   = "hello world"
     end


### PR DESCRIPTION
If a custom URL normaliser does not filter out white-space, raise an exception to prevent CRLF injection. Whitespace, in particular `\n`, is never allowed in path, query or hostname.

This is not a security fix as such but an extra line of defence.