### PR TITLE
 Handle responses in the reverse order from the requests

### DIFF
--- a/lib/http/client.rb
+++ b/lib/http/client.rb
@@ -81,7 +81,7 @@ module HTTP
       end
       res = build_response(req, options)
 
-      res = options.features.inject(res) do |response, (_name, feature)|
+      res = options.features.values.reverse.inject(res) do |response, feature|
         feature.wrap_response(response)
       end
 


### PR DESCRIPTION
Resolve https://github.com/httprb/http/issues/767


BREAKING CHANGE:

* multiple features execution depends on order, e.g. `HTTP.use(:auto_inflate, :logging)`
* [replay function in webmock](https://github.com/bblimke/webmock/blob/63940ac95345968cf435820a62102d913441862c/lib/webmock/http_lib_adapters/http_rb/webmock.rb#L46).