### PR TITLE
Update base64 dependency version

### DIFF
--- a/http.gemspec
+++ b/http.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 3.0"
 
   gem.add_runtime_dependency "addressable",    "~> 2.8"
-  gem.add_runtime_dependency "base64",         "~> 0.1"
+  gem.add_runtime_dependency "base64",         "~> 0.2"
   gem.add_runtime_dependency "http-cookie",    "~> 1.0"
   gem.add_runtime_dependency "http-form_data", "~> 2.2"
   gem.add_runtime_dependency "llhttp-ffi",     "~> 0.5.0"


### PR DESCRIPTION
Hi, I'm getting the following error when trying to use the HTTP gem with Rails 7.1.3:

```
You have already activated base64 0.1.1, but your Gemfile requires base64 0.2.0. Since base64 is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports base64 as a default gem. (Gem::LoadError)
```

RUBY VERSION
   ruby 3.2.3p157

BUNDLED WITH
   2.5.6

It looks like this will happen until ruby 3.4 when base64 is removed from the default gems. Since there weren't any API changes in the base64 gem since 0.1.1 despite the minor version update, it looks like this version is safe to bump: https://github.com/ruby/base64/releases.

I think removing the dependency like in #778 is preferable, but while that awaits review, we can bump the version here.