### PR TITLE
Fixes comment typo in errors.rb

### DIFF
--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -19,7 +19,7 @@ module HTTP
   # Generic Timeout error
   class TimeoutError < Error; end
 
-  # Timeout when first establishing the conncetion
+  # Timeout when first establishing the connection
   class ConnectTimeoutError < TimeoutError; end
 
   # Header value is of unexpected format (similar to Net::HTTPHeaderSyntaxError)


### PR DESCRIPTION
`connection` was misspelled