### PR TITLE
Add more granularity to `ConnectionError` through more specific error classes

### DIFF
--- a/lib/http/connection.rb
+++ b/lib/http/connection.rb
@@ -105,10 +105,11 @@ module HTTP
 
     # Reads data from socket up until headers are loaded
     # @return [void]
+    # @raise [ResponseHeaderError] when unable to read response headers
     def read_headers!
       until @parser.headers?
         result = read_more(BUFFER_SIZE)
-        raise ConnectionError, "couldn't read response headers" if result == :eof
+        raise ResponseHeaderError, "couldn't read response headers" if result == :eof
       end
 
       set_keep_alive
@@ -217,6 +218,7 @@ module HTTP
 
     # Feeds some more data into parser
     # @return [void]
+    # @raise [SocketReadError] when unable to read from socket
     def read_more(size)
       return if @parser.finished?
 
@@ -228,7 +230,7 @@ module HTTP
         @parser << value
       end
     rescue IOError, SocketError, SystemCallError => e
-      raise ConnectionError, "error reading from socket: #{e}", e.backtrace
+      raise SocketReadError, "error reading from socket: #{e}", e.backtrace
     end
   end
 end

--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -6,6 +6,8 @@ module HTTP
 
   # Generic Connection error
   class ConnectionError < Error; end
+
+  # Types of Connection errors
   class ResponseHeaderError < ConnectionError; end
   class SocketReadError < ConnectionError; end
   class SocketWriteError < ConnectionError; end

--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -6,6 +6,9 @@ module HTTP
 
   # Generic Connection error
   class ConnectionError < Error; end
+  class ResponseHeaderError < ConnectionError; end
+  class SocketReadError < ConnectionError; end
+  class SocketWriteError < ConnectionError; end
 
   # Generic Request error
   class RequestError < Error; end

--- a/lib/http/request/writer.rb
+++ b/lib/http/request/writer.rb
@@ -108,6 +108,7 @@ module HTTP
 
       private
 
+      # @raise [SocketWriteError] when unable to write to socket
       def write(data)
         until data.empty?
           length = @socket.write(data)
@@ -118,7 +119,7 @@ module HTTP
       rescue Errno::EPIPE
         raise
       rescue IOError, SocketError, SystemCallError => e
-        raise ConnectionError, "error writing to socket: #{e}", e.backtrace
+        raise SocketWriteError, "error writing to socket: #{e}", e.backtrace
       end
     end
   end


### PR DESCRIPTION
- would love to have more granularity into what kind of Connection error is being thrown
- this PR changes 3/4 `ConnectionError` throws to use subclasses specific to that failure mode
- this is backwards compatible because they are subclasses of `ConnectionError` so this should not affect any existing `rescue` logic
- open to feedback!