### PR TITLE
Bump rubocop to v1.61

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :test do
 
   gem "backports"
 
-  gem "rubocop", "~> 1.57.0"
+  gem "rubocop", "~> 1.61.0"
   gem "rubocop-performance", "~> 1.19.1"
   gem "rubocop-rake", "~> 0.6.0"
   gem "rubocop-rspec", "~> 2.24.1"

--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -102,7 +102,7 @@ module HTTP
       %i[global read write connect].each do |k|
         next unless options.key? k
 
-        options["#{k}_timeout".to_sym] = options.delete k
+        options[:"#{k}_timeout"] = options.delete k
       end
 
       branch default_options.merge(

--- a/lib/http/response/status/reasons.rb
+++ b/lib/http/response/status/reasons.rb
@@ -75,7 +75,7 @@ module HTTP
         508 => "Loop Detected",
         510 => "Not Extended",
         511 => "Network Authentication Required"
-      }.each { |_, v| v.freeze }.freeze
+      }.each_value(&:freeze).freeze
     end
   end
 end

--- a/spec/support/proxy_server.rb
+++ b/spec/support/proxy_server.rb
@@ -18,7 +18,7 @@ class ProxyServer < WEBrick::HTTPProxyServer
   }.freeze
 
   def initialize
-    super CONFIG
+    super(CONFIG)
   end
 end
 
@@ -34,6 +34,6 @@ class AuthProxyServer < WEBrick::HTTPProxyServer
   CONFIG = ProxyServer::CONFIG.merge ProxyAuthProc: AUTHENTICATOR
 
   def initialize
-    super CONFIG
+    super(CONFIG)
   end
 end


### PR DESCRIPTION
This is the minimum version that will bundle against our other dependencies.

I tried going to the latest version (1.65.0) but it added new lints whose autocorrections break the tests, so this should at least get the build green again.