### PR TITLE
New feature: RaiseError

### DIFF
--- a/lib/http/chainable.rb
+++ b/lib/http/chainable.rb
@@ -243,6 +243,7 @@ module HTTP
     # * instrumentation
     # * logging
     # * normalize_uri
+    # * raise_error
     # @param features
     def use(*features)
       branch default_options.with_features(features)

--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -22,7 +22,15 @@ module HTTP
   class StateError < ResponseError; end
 
   # When status code indicates an error
-  class StatusError < ResponseError; end
+  class StatusError < ResponseError
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+
+      super("Unexpected status code #{response.code}")
+    end
+  end
 
   # Generic Timeout error
   class TimeoutError < Error; end

--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -21,6 +21,9 @@ module HTTP
   # Requested to do something when we're in the wrong state
   class StateError < ResponseError; end
 
+  # When status code indicates an error
+  class StatusError < ResponseError; end
+
   # Generic Timeout error
   class TimeoutError < Error; end
 

--- a/lib/http/feature.rb
+++ b/lib/http/feature.rb
@@ -16,6 +16,7 @@ end
 
 require "http/features/auto_inflate"
 require "http/features/auto_deflate"
-require "http/features/logging"
 require "http/features/instrumentation"
+require "http/features/logging"
 require "http/features/normalize_uri"
+require "http/features/raise_error"

--- a/lib/http/features/raise_error.rb
+++ b/lib/http/features/raise_error.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module HTTP
+  module Features
+    class RaiseError < Feature
+      def initialize(ignore: [])
+        super()
+
+        @ignore = ignore
+      end
+
+      def wrap_response(response)
+        if response.code >= 400 && !@ignore.include?(response.code)
+          raise HTTP::StatusError, "Unexpected status code #{response.code}"
+        end
+
+        response
+      end
+
+      HTTP::Options.register_feature(:raise_error, self)
+    end
+  end
+end

--- a/lib/http/features/raise_error.rb
+++ b/lib/http/features/raise_error.rb
@@ -10,11 +10,10 @@ module HTTP
       end
 
       def wrap_response(response)
-        if response.code >= 400 && !@ignore.include?(response.code)
-          raise HTTP::StatusError, "Unexpected status code #{response.code}"
-        end
+        return response if response.code < 400
+        return response if @ignore.include?(response.code)
 
-        response
+        raise HTTP::StatusError, response
       end
 
       HTTP::Options.register_feature(:raise_error, self)

--- a/spec/lib/http/features/raise_error_spec.rb
+++ b/spec/lib/http/features/raise_error_spec.rb
@@ -52,10 +52,10 @@ RSpec.describe HTTP::Features::RaiseError do
 
     context "when error status is ignored" do
       let(:status) { 500 }
-      let(:ignored) { [500] }
+      let(:ignore) { [500] }
 
-      it "raises" do
-        expect { result }.to raise_error(HTTP::StatusError, "Unexpected status code 500")
+      it "returns original request" do
+        expect(result).to be response
       end
     end
   end

--- a/spec/lib/http/features/raise_error_spec.rb
+++ b/spec/lib/http/features/raise_error_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe HTTP::Features::RaiseError do
+  subject(:feature) { described_class.new(ignore: ignore) }
+
+  let(:connection) { double }
+  let(:status) { 200 }
+  let(:ignore) { [] }
+
+  describe "#wrap_response" do
+    subject(:result) { feature.wrap_response(response) }
+
+    let(:response) do
+      HTTP::Response.new(
+        version:    "1.1",
+        status:     status,
+        headers:    {},
+        connection: connection,
+        request:    HTTP::Request.new(verb: :get, uri: "https://example.com")
+      )
+    end
+
+    context "when status is 200" do
+      it "returns original request" do
+        expect(result).to be response
+      end
+    end
+
+    context "when status is 399" do
+      let(:status) { 399 }
+
+      it "returns original request" do
+        expect(result).to be response
+      end
+    end
+
+    context "when status is 400" do
+      let(:status) { 400 }
+
+      it "raises" do
+        expect { result }.to raise_error(HTTP::StatusError, "Unexpected status code 400")
+      end
+    end
+
+    context "when status is 599" do
+      let(:status) { 599 }
+
+      it "raises" do
+        expect { result }.to raise_error(HTTP::StatusError, "Unexpected status code 599")
+      end
+    end
+
+    context "when error status is ignored" do
+      let(:status) { 500 }
+      let(:ignored) { [500] }
+
+      it "raises" do
+        expect { result }.to raise_error(HTTP::StatusError, "Unexpected status code 500")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The library raises errors if the server does various unexpected things, e.g. `TooManyRedirectsError`, but it does not raise if the HTTP status code indicates a client error (4xx) or server (5xx) error.

Sometimes you are interested in non-successful responses, and sometimes you just want to treat them as any other error triggered by the server.

This PR adds a new feature that will raise an exception on status codes representing an error. If you want to skip this for specific codes, you can specify them in the `ignore` option.