### PR TITLE
Implement RFC 8305, the "Happy Eyeballs".

### DIFF
--- a/lib/http/network/tcp_socket.rb
+++ b/lib/http/network/tcp_socket.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "socket"
+
+module HTTP
+  module Network
+    class TCPSocket
+      class << self
+        def new(...)
+          ::Socket.tcp(...)
+        end
+
+        def open(...)
+          new(...)
+        end
+      end
+    end
+  end
+end

--- a/lib/http/options.rb
+++ b/lib/http/options.rb
@@ -2,12 +2,12 @@
 
 require "http/headers"
 require "openssl"
-require "socket"
+require "http/network/tcp_socket"
 require "http/uri"
 
 module HTTP
   class Options # rubocop:disable Metrics/ClassLength
-    @default_socket_class     = TCPSocket
+    @default_socket_class     = Network::TCPSocket
     @default_ssl_socket_class = OpenSSL::SSL::SSLSocket
     @default_timeout_class    = HTTP::Timeout::Null
     @available_features       = {}

--- a/spec/lib/http/client_spec.rb
+++ b/spec/lib/http/client_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe HTTP::Client do
       end
 
       it "is given a chance to handle a connection timeout error" do
-        allow(TCPSocket).to receive(:open) { sleep 1 }
+        allow(HTTP::Network::TCPSocket).to receive(:open) { sleep 1 }
         sleep_url = "#{dummy.endpoint}/sleep"
         feature_instance = feature_class.new
 
@@ -570,7 +570,7 @@ RSpec.describe HTTP::Client do
         allow(socket_spy).to receive(:readpartial) { chunks.shift || :eof }
         allow(socket_spy).to receive(:write) { chunks[0].length }
 
-        allow(TCPSocket).to receive(:open) { socket_spy }
+        allow(HTTP::Network::TCPSocket).to receive(:open) { socket_spy }
       end
 
       it "properly reads body" do

--- a/spec/support/http_handling_shared.rb
+++ b/spec/support/http_handling_shared.rb
@@ -73,7 +73,7 @@ RSpec.shared_context "HTTP handling" do
     let(:response) { client.get(server.endpoint).body.to_s }
 
     it "errors if connecting takes too long" do
-      expect(TCPSocket).to receive(:open) do
+      expect(HTTP::Network::TCPSocket).to receive(:open) do
         sleep 1.25
       end
 


### PR DESCRIPTION
### Overview
This addresses https://github.com/httprb/http/issues/739.

Happy Eyeballs landed in Ruby for quite some time. :tada:
https://bugs.ruby-lang.org/issues/20108

However, it does not reach HTTP.rb yet.
This is because HTTP.rb uses [TCPSocket](https://docs.ruby-lang.org/en/master/TCPSocket.html).[open](https://docs.ruby-lang.org/en/master/IO.html#method-c-open) by default.

### Source traces
* `open` was implemented in the IO class as an alias to `new`.  
https://github.com/ruby/ruby/blob/37a16c7812f5b7e6faa762b927e9f04065cc495a/io.c#L8124
* In the case of `TCPSocket`, it is bound directly to the c source code.  
https://github.com/ruby/ruby/blob/6deeec5d459ecff5ec4628523b14ac7379fd942e/ext/socket/tcpsocket.c#L54
* But Happy Eyeballs was implemented in the Ruby layer.  
https://github.com/ruby/ruby/commit/9ec342e07df6aa5e2c2e9003517753a2f1b508fd

### A baby step
In order to take advantage of the new feature. I alias `default_socket_class` to `Socket.tcp` so the connection logic will be handled by the Ruby layer of `Socket`.

### Rough edges
For your information `Socket.tcp` has a lot of features beyond Happy Eyeballs.
For example, it supports `connect_timeout` natively.
What to do with https://github.com/httprb/http/blob/db6863ab48fdd77178078b3128a9db3d0ad6069a/lib/http/timeout/global.rb#L24 needs more discussions.
This is just one aspect of it.

Nevertheless, this baby step would introduce minimal breaking changes. (or any changes at all)
Providing more robust connections.