### PR TITLE
Remove circular require

### DIFF
--- a/lib/http/retriable/performer.rb
+++ b/lib/http/retriable/performer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "date"
-require "http"
 require "http/retriable/errors"
 require "http/retriable/delay_calculator"
 require "openssl"


### PR DESCRIPTION
This fixes a circular require warning I encountered in [Peddler](https://github.com/lineofflight/peddler) when testing against the main branch of HTTP.rb.