### PR TITLE
Add ruby 3.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [ ruby-3.0, ruby-3.1, ruby-3.2, ruby-3.3 ]
+        ruby: [ ruby-3.0, ruby-3.1, ruby-3.2, ruby-3.3, ruby-3.4 ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ the following Ruby  versions:
 - Ruby 3.1
 - Ruby 3.2
 - Ruby 3.3
+- Ruby 3.4
 - JRuby 9.4
 
 If something doesn't work on one of these versions, it's a bug.


### PR DESCRIPTION
`Hash#inspect` output changed in Ruby-3.4 thus specs were failing. But even without that I don't think dumping all headers in `Response#inspect` was pointless, same about `Headers#inspect`.