### PR TITLE
fix: Simplify response and headers inspection

### DIFF
--- a/lib/http/headers.rb
+++ b/lib/http/headers.rb
@@ -147,7 +147,7 @@ module HTTP
     #
     # @return [String]
     def inspect
-      "#<#{self.class} #{to_h.inspect}>"
+      "#<#{self.class}>"
     end
 
     # Returns list of header names.

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -162,7 +162,7 @@ module HTTP
 
     # Inspect a response
     def inspect
-      "#<#{self.class}/#{@version} #{code} #{reason} #{headers.to_h.inspect}>"
+      "#<#{self.class}/#{@version} #{code} #{reason} #{mime_type}>"
     end
 
     private

--- a/spec/lib/http/headers_spec.rb
+++ b/spec/lib/http/headers_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe HTTP::Headers do
 
     before  { headers.set :set_cookie, %w[hoo=ray woo=hoo] }
 
-    it { is_expected.to eq '#<HTTP::Headers {"Set-Cookie"=>["hoo=ray", "woo=hoo"]}>' }
+    it { is_expected.to eq "#<HTTP::Headers>" }
   end
 
   describe "#keys" do

--- a/spec/lib/http/response_spec.rb
+++ b/spec/lib/http/response_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe HTTP::Response do
     let(:headers) { {content_type: "text/plain"} }
     let(:body)    { double to_s: "foobar" }
 
-    it { is_expected.to eq '#<HTTP::Response/1.1 200 OK {"Content-Type"=>"text/plain"}>' }
+    it { is_expected.to eq "#<HTTP::Response/1.1 200 OK text/plain>" }
   end
 
   describe "#cookies" do


### PR DESCRIPTION
* Dumping all headers in `Headers#inspect` mostly useless
* Same about response, the only header part that is meaningfull there is MIME type

More importantly, Ruby-3.4 changed the inspect output, and we will either need to have if/else in specs, or modify the output to become ruby version-agnostic (i.e., not using Hash#inspect).

Blocks: https://github.com/httprb/http/pull/808