### PR TITLE
When retrying request also retry features

### DIFF
--- a/lib/http/retriable/performer.rb
+++ b/lib/http/retriable/performer.rb
@@ -70,6 +70,11 @@ module HTTP
           elsif res
             return res
           end
+
+          # re-trigger each feature, we are about to start the request again
+          client.default_options.features.each_value do |feature|
+            feature.wrap_request(req)
+          end
         end
       end
 

--- a/spec/lib/http/retriable/performer_spec.rb
+++ b/spec/lib/http/retriable/performer_spec.rb
@@ -247,10 +247,24 @@ RSpec.describe HTTP::Retriable::Performer do
         expect(counter_spy).to eq 5
       end
     end
+
+    describe "when client has other features enabled" do
+      let(:client) { HTTP.retriable.use(:dummy) }
+
+      it "retries them as well" do
+        expect do
+          perform({ retry_statuses: [200], tries: 5 }, client) do
+            response
+          end
+        end.to raise_error(HTTP::OutOfRetriesError)
+
+        expect(DummyFeature.instance.wrap_request_called_with.length).to eq(4)
+      end
+    end
   end
 
   describe "connection closing" do
-    let(:client) { double(:client) }
+    let(:client) { double(:client, default_options: double(:options, features: {})) }
 
     it "does not close the connection if we get a propper response" do
       expect(client).not_to receive(:close)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require "rspec/its"
 require "rspec/memory"
 require "support/capture_warning"
 require "support/fakeio"
+require "support/dummy_feature"
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|

--- a/spec/support/dummy_feature.rb
+++ b/spec/support/dummy_feature.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class DummyFeature < HTTP::Feature
+  class << self
+    def instance
+      @instance ||=
+        begin
+          i = allocate
+          i.send(:initialize)
+          i
+        end
+    end
+
+    def new
+      instance
+    end
+  end
+
+  def initialize
+    super
+    reset!
+  end
+
+  attr_reader :wrap_request_called_with, :wrap_response_called_with, :on_error_called_with
+
+  def wrap_request(request)
+    @wrap_request_called_with << request
+  end
+
+  def wrap_response(response)
+    @wrap_response_called_with << response
+  end
+
+  def on_error(request, error)
+    @on_error_called_with << [request, error]
+  end
+
+  def reset!
+    @wrap_request_called_with = []
+    @wrap_response_called_with = []
+    @on_error_called_with = []
+  end
+
+  HTTP::Options.register_feature(:dummy, self)
+end
+
+RSpec.configure do |config|
+  config.before do
+    DummyFeature.instance.reset!
+  end
+end


### PR DESCRIPTION
Closes https://github.com/httprb/http/issues/826.

1. This PR changes `Retriable` to also restart all features when starting a retry.
2. I've added a `DummyFeature` class to simplify testing, I hope it's OK.
3. `include Singleton` can't be used there because HTTP.rb calls `FeatureClass.new`. However, we need `.instance`, so `allocate -> initialize` is used instead. If you know a better solution please LMK.