### PR TITLE
Fix RBS syntax error

### DIFF
--- a/sig/http.rbs
+++ b/sig/http.rbs
@@ -1272,7 +1272,7 @@ module HTTP
       def size: () -> Integer
 
       # Rewinds the IO to the beginning
-      def rewind: () -> (Integer | void)
+      def rewind: () -> void
     end
 
     class Part


### PR DESCRIPTION
 The newly-released RBS 4.0 rejects `void` in union types at the parser level. The `(Integer | void)` return type on `Readable#rewind` now causes a hard parse error.

Change to `void`, consistent with CompositeIO#rewind and the YARD @return annotation.