### PR TITLE
Raise specific error classes for 4xx and 5xx errors

### DIFF
--- a/lib/http/errors.rb
+++ b/lib/http/errors.rb
@@ -49,6 +49,52 @@ module HTTP
     end
   end
 
+  # Client errors 4xx
+  class ClientError < StatusError; end
+  class BadRequestError < ClientError; end
+  class UnauthorizedError < ClientError; end
+  class PaymentRequiredError < ClientError; end
+  class ForbiddenError < ClientError; end
+  class NotFoundError < ClientError; end
+  class MethodNotAllowedError < ClientError; end
+  class NotAcceptableError < ClientError; end
+  class ProxyAuthenticationRequiredError < ClientError; end
+  class RequestTimeoutError < ClientError; end
+  class ConflictError < ClientError; end
+  class GoneError < ClientError; end
+  class LengthRequiredError < ClientError; end
+  class PreconditionFailedError < ClientError; end
+  class ContentTooLargeError < ClientError; end
+  class UriTooLongError < ClientError; end
+  class UnsupportedMediaTypeError < ClientError; end
+  class RangeNotSatisfiableError < ClientError; end
+  class ExpectationFailedError < ClientError; end
+  class ImATeapotError < ClientError; end
+  class MisdirectedRequestError < ClientError; end
+  class UnprocessableContentError < ClientError; end
+  class LockedError < ClientError; end
+  class FailedDependencyError < ClientError; end
+  class TooEarlyError < ClientError; end
+  class UpgradeRequiredError < ClientError; end
+  class PreconditionRequiredError < ClientError; end
+  class TooManyRequestsError < ClientError; end
+  class RequestHeaderFieldsTooLargeError < ClientError; end
+  class UnavailableForLegalReasonsError < ClientError; end
+
+  # Server errors 5xx
+  class ServerError < StatusError; end
+  class InternalServerError < ServerError; end
+  class NotImplementedError < ServerError; end
+  class BadGatewayError < ServerError; end
+  class ServiceUnavailableError < ServerError; end
+  class GatewayTimeoutError < ServerError; end
+  class HttpVersionNotSupportedError < ServerError; end
+  class VariantAlsoNegotiatesError < ServerError; end
+  class InsufficientStorageError < ServerError; end
+  class LoopDetectedError < ServerError; end
+  class NotExtendedError < ServerError; end
+  class NetworkAuthenticationRequiredError < ServerError; end
+
   # Raised when `Response#parse` fails due to any underlying reason (unexpected
   # MIME type, or decoder fails). See `Exception#cause` for the original exception.
   class ParseError < ResponseError; end

--- a/lib/http/features/raise_error.rb
+++ b/lib/http/features/raise_error.rb
@@ -4,6 +4,49 @@ module HTTP
   module Features
     # Raises an error for non-successful HTTP responses
     class RaiseError < Feature
+      CODE_TO_ERROR_CLASS = {
+        400 => BadRequestError,
+        401 => UnauthorizedError,
+        402 => PaymentRequiredError,
+        403 => ForbiddenError,
+        404 => NotFoundError,
+        405 => MethodNotAllowedError,
+        406 => NotAcceptableError,
+        407 => ProxyAuthenticationRequiredError,
+        408 => RequestTimeoutError,
+        409 => ConflictError,
+        410 => GoneError,
+        411 => LengthRequiredError,
+        412 => PreconditionFailedError,
+        413 => ContentTooLargeError,
+        414 => UriTooLongError,
+        415 => UnsupportedMediaTypeError,
+        416 => RangeNotSatisfiableError,
+        417 => ExpectationFailedError,
+        418 => ImATeapotError,
+        421 => MisdirectedRequestError,
+        422 => UnprocessableContentError,
+        423 => LockedError,
+        424 => FailedDependencyError,
+        425 => TooEarlyError,
+        426 => UpgradeRequiredError,
+        428 => PreconditionRequiredError,
+        429 => TooManyRequestsError,
+        431 => RequestHeaderFieldsTooLargeError,
+        451 => UnavailableForLegalReasonsError,
+        500 => InternalServerError,
+        501 => NotImplementedError,
+        502 => BadGatewayError,
+        503 => ServiceUnavailableError,
+        504 => GatewayTimeoutError,
+        505 => HttpVersionNotSupportedError,
+        506 => VariantAlsoNegotiatesError,
+        507 => InsufficientStorageError,
+        508 => LoopDetectedError,
+        510 => NotExtendedError,
+        511 => NetworkAuthenticationRequiredError
+      }.freeze
+
       # Initializes the RaiseError feature
       #
       # @example
@@ -28,54 +71,14 @@ module HTTP
         return response if response.code < 400
         return response if @ignore.include?(response.code)
 
-        error_class =
+        default_error_class =
           case response.code
-          when 400 then BadRequestError
-          when 401 then UnauthorizedError
-          when 402 then PaymentRequiredError
-          when 403 then ForbiddenError
-          when 404 then NotFoundError
-          when 405 then MethodNotAllowedError
-          when 406 then NotAcceptableError
-          when 407 then ProxyAuthenticationRequiredError
-          when 408 then RequestTimeoutError
-          when 409 then ConflictError
-          when 410 then GoneError
-          when 411 then LengthRequiredError
-          when 412 then PreconditionFailedError
-          when 413 then ContentTooLargeError
-          when 414 then UriTooLongError
-          when 415 then UnsupportedMediaTypeError
-          when 416 then RangeNotSatisfiableError
-          when 417 then ExpectationFailedError
-          when 418 then ImATeapotError
-          when 421 then MisdirectedRequestError
-          when 422 then UnprocessableContentError
-          when 423 then LockedError
-          when 424 then FailedDependencyError
-          when 425 then TooEarlyError
-          when 426 then UpgradeRequiredError
-          when 428 then PreconditionRequiredError
-          when 429 then TooManyRequestsError
-          when 431 then RequestHeaderFieldsTooLargeError
-          when 451 then UnavailableForLegalReasonsError
-          when 400...500 then ClientError # Generic client error if the 4xx code is unmapped.
-          when 500 then InternalServerError
-          when 501 then NotImplementedError
-          when 502 then BadGatewayError
-          when 503 then ServiceUnavailableError
-          when 504 then GatewayTimeoutError
-          when 505 then HttpVersionNotSupportedError
-          when 506 then VariantAlsoNegotiatesError
-          when 507 then InsufficientStorageError
-          when 508 then LoopDetectedError
-          when 510 then NotExtendedError
-          when 511 then NetworkAuthenticationRequiredError
-          when 500...600 then ServerError # Generic server error if the 5xx code is unmapped.
+          when 400...500 then ClientError
+          when 500...600 then ServerError
           else StatusError
           end
 
-        raise error_class, response
+        raise CODE_TO_ERROR_CLASS.fetch(response.code, default_error_class), response
       end
 
       HTTP::Options.register_feature(:raise_error, self)

--- a/lib/http/features/raise_error.rb
+++ b/lib/http/features/raise_error.rb
@@ -28,7 +28,54 @@ module HTTP
         return response if response.code < 400
         return response if @ignore.include?(response.code)
 
-        raise StatusError, response
+        error_class =
+          case response.code
+          when 400 then BadRequestError
+          when 401 then UnauthorizedError
+          when 402 then PaymentRequiredError
+          when 403 then ForbiddenError
+          when 404 then NotFoundError
+          when 405 then MethodNotAllowedError
+          when 406 then NotAcceptableError
+          when 407 then ProxyAuthenticationRequiredError
+          when 408 then RequestTimeoutError
+          when 409 then ConflictError
+          when 410 then GoneError
+          when 411 then LengthRequiredError
+          when 412 then PreconditionFailedError
+          when 413 then ContentTooLargeError
+          when 414 then UriTooLongError
+          when 415 then UnsupportedMediaTypeError
+          when 416 then RangeNotSatisfiableError
+          when 417 then ExpectationFailedError
+          when 418 then ImATeapotError
+          when 421 then MisdirectedRequestError
+          when 422 then UnprocessableContentError
+          when 423 then LockedError
+          when 424 then FailedDependencyError
+          when 425 then TooEarlyError
+          when 426 then UpgradeRequiredError
+          when 428 then PreconditionRequiredError
+          when 429 then TooManyRequestsError
+          when 431 then RequestHeaderFieldsTooLargeError
+          when 451 then UnavailableForLegalReasonsError
+          when 400...500 then ClientError # Generic client error if the 4xx code is unmapped.
+          when 500 then InternalServerError
+          when 501 then NotImplementedError
+          when 502 then BadGatewayError
+          when 503 then ServiceUnavailableError
+          when 504 then GatewayTimeoutError
+          when 505 then HttpVersionNotSupportedError
+          when 506 then VariantAlsoNegotiatesError
+          when 507 then InsufficientStorageError
+          when 508 then LoopDetectedError
+          when 510 then NotExtendedError
+          when 511 then NetworkAuthenticationRequiredError
+          when 500...600 then ServerError # Generic server error if the 5xx code is unmapped.
+          else StatusError
+          end
+
+        raise error_class, response
       end
 
       HTTP::Options.register_feature(:raise_error, self)

--- a/test/http/features/raise_error_test.rb
+++ b/test/http/features/raise_error_test.rb
@@ -37,26 +37,32 @@ class HTTPFeaturesRaiseErrorTest < Minitest::Test
     assert_same response, result
   end
 
-  def test_wrap_response_when_status_is_400_raises
+  def test_wrap_response_when_status_is_400_raises_bad_request_error
     feature = HTTP::Features::RaiseError.new(ignore: [])
     response = build_response(status: 400)
-    err = assert_raises(HTTP::StatusError) { feature.wrap_response(response) }
+    err = assert_raises(HTTP::BadRequestError) { feature.wrap_response(response) }
     assert_equal "Unexpected status code 400", err.message
   end
 
-  def test_wrap_response_when_status_is_599_raises
+  def test_wrap_response_when_status_is_500_raises_internal_server_error
     feature = HTTP::Features::RaiseError.new(ignore: [])
-    response = build_response(status: 599)
-    err = assert_raises(HTTP::StatusError) { feature.wrap_response(response) }
-    assert_equal "Unexpected status code 599", err.message
+    response = build_response(status: 500)
+    err = assert_raises(HTTP::InternalServerError) { feature.wrap_response(response) }
+    assert_equal "Unexpected status code 500", err.message
   end
 
-  def test_wrap_response_when_error_status_is_ignored_returns_original_response
-    feature = HTTP::Features::RaiseError.new(ignore: [500])
-    response = build_response(status: 500)
-    result = feature.wrap_response(response)
+  def test_wrap_response_when_unmapped_4xx_status_raises_client_error
+    feature = HTTP::Features::RaiseError.new(ignore: [])
+    response = build_response(status: 499)
+    err = assert_raises(HTTP::ClientError) { feature.wrap_response(response) }
+    assert_equal "Unexpected status code 499", err.message
+  end
 
-    assert_same response, result
+  def test_wrap_response_when_unmapped_5xx_status_raises_server_error
+    feature = HTTP::Features::RaiseError.new(ignore: [])
+    response = build_response(status: 599)
+    err = assert_raises(HTTP::ServerError) { feature.wrap_response(response) }
+    assert_equal "Unexpected status code 599", err.message
   end
 
   # -- #initialize --

--- a/test/http/features/raise_error_test.rb
+++ b/test/http/features/raise_error_test.rb
@@ -65,6 +65,15 @@ class HTTPFeaturesRaiseErrorTest < Minitest::Test
     assert_equal "Unexpected status code 599", err.message
   end
 
+  def test_each_error_code
+    HTTP::Features::RaiseError::CODE_TO_ERROR_CLASS.each do |status, expected_error_class|
+      feature = HTTP::Features::RaiseError.new(ignore: [])
+      response = build_response(status: status)
+      err = assert_raises(expected_error_class) { feature.wrap_response(response) }
+      refute_nil err.message
+    end
+  end
+
   # -- #initialize --
 
   def test_initialize_defaults_ignore_to_empty_array

--- a/test/http/features/raise_error_test.rb
+++ b/test/http/features/raise_error_test.rb
@@ -89,4 +89,20 @@ class HTTPFeaturesRaiseErrorTest < Minitest::Test
   def test_initialize_is_a_feature
     assert_kind_of HTTP::Feature, HTTP::Features::RaiseError.new
   end
+
+  def test_wrap_response_when_status_is_400_and_ignored_returns_original_response
+    feature = HTTP::Features::RaiseError.new(ignore: [400])
+    response = build_response(status: 400)
+    result = feature.wrap_response(response)
+
+    assert_same response, result
+  end
+
+  def test_wrap_response_when_status_is_500_and_ignored_returns_original_response
+    feature = HTTP::Features::RaiseError.new(ignore: [500])
+    response = build_response(status: 500)
+    result = feature.wrap_response(response)
+
+    assert_same response, result
+  end
 end


### PR DESCRIPTION
# Context/problem

When using the `http.rb` gem in production code, I often find myself writing boilerplate code to wrap the `StatusError` thrown by the gem and raise a more specific error based on the response code.

```ruby
begin
  HTTP.post(...)
rescue HTTP::StatusError => e
  case e.response.code
  when 401
    raise UnauthorizedError
  when 409
    raise ConflictError
  ...
  end
end
```

This is often in some client class or shared HTTP classes that can be used across the codebase. This works, but has a few issues:
1. The custom error classes need to also implement a `response` instance var to be useful. You end up re-implementing `StatusError` in the app, or you inherit directly from the gem class.
2. This code is repetitive

# Proposal (this PR)

I would like to propose that the HTTP gem enumerate the roughly ~40 or so 4xx and 5xx [status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status). This would provide a clean interface that allows callers to catch errors at varying levels of granularity, **while being fully backwards compatible.**

To achieve this, I'd like to propose 2 subclasses of `StatusError`:
1. `ClientError`, an entry point for all 4xx errors
2. `ServerError`, an entry point for all 5xx errors

Because all specific error classes are ultimately instances of `StatusError`, this should not break any existing `rescue` blocks. Users can opt-in to more granular errors as they see fit. 

## Example migration

**Existing code**

```ruby
begin
  HTTP.post
rescue StatusError => e
  if e.response.code >= 500 ||
    retry
  elsif e.response.code == 429
    sleep(1) # throttle
    retry
  else
    fail
  end
end
```

**After change**

Existing code still works as-is

```ruby
begin
  HTTP.post
rescue ServerError # all 5xx
  retry
rescue TooManyRequestsError # 429
  sleep(1) # throttle
  retry
rescue ClientError # all other 4xx
  fail
end
```

Would love any feedback or thoughts, thanks.