### PR TITLE
Skip Timeout.timeout wrap when TCPSocket native connect_timeout is available

### DIFF
--- a/lib/http/timeout/null.rb
+++ b/lib/http/timeout/null.rb
@@ -185,12 +185,14 @@ module HTTP
       # @return [Object] the connected socket
       # @api private
       def open_socket(socket_class, host, port, connect_timeout: nil)
-        if connect_timeout
+        return socket_class.open(host, port) unless connect_timeout
+
+        if native_timeout?(socket_class)
+          open_with_timeout(socket_class, host, port, connect_timeout)
+        else
           ::Timeout.timeout(connect_timeout, ConnectTimeoutError) do
             open_with_timeout(socket_class, host, port, connect_timeout)
           end
-        else
-          socket_class.open(host, port)
         end
       rescue IO::TimeoutError
         raise ConnectTimeoutError, "Connect timed out after #{connect_timeout} seconds"

--- a/test/http/client_test.rb
+++ b/test/http/client_test.rb
@@ -402,7 +402,7 @@ class HTTPClientTest < Minitest::Test
     sleep_url = "#{dummy.endpoint}/sleep"
     feature_instance = feature_class.new
 
-    TCPSocket.stub(:open, ->(*) { sleep 0.1 }) do
+    TCPSocket.stub(:open, ->(*, **) { raise IO::TimeoutError }) do
       assert_raises(HTTP::ConnectTimeoutError) do
         client.use(test_feature: feature_instance)
               .timeout(0.001)

--- a/test/support/http_handling_shared/timeout_tests.rb
+++ b/test/support/http_handling_shared/timeout_tests.rb
@@ -72,9 +72,9 @@ module TimeoutTests
       timeout_options: { global_timeout: 0.01 }
     )
 
-    TCPSocket.stub(:open, ->(*) { sleep 0.025 }) do
+    TCPSocket.stub(:open, ->(*, **) { raise IO::TimeoutError }) do
       err = assert_raises(HTTP::ConnectTimeoutError) { client.get(server.endpoint).body.to_s }
-      assert_match(/execution/, err.message)
+      assert_match(/Connect timed out|execution/, err.message)
     end
   end
 


### PR DESCRIPTION
We are always wrapping in Timeout.timeout when a connect_timeout is set, even when native socket connect_timeout is available. The native timeout already enforces the limit and raises IO::TimeoutError, so the wrap is redundant.

Using Timeout.timeout is problematic: under certain exit paths, the Timeout::Request is not removed from the Timeout watcher's internal request queue, retaining the target Thread for the process lifetime. In long-running workers (Sidekiq, Puma in some configurations) this surfaces as slow memory growth.

Looks like this was meant to be avoided when native timeout support was added - the comment above the method even says "Falls back to Timeout.timeout on older Rubies or with custom socket classes" - but the code applies the wrap unconditionally. This PR makes the behavior match the comment.

I think this PR basically resolves https://github.com/httprb/http/issues/542