### PR TITLE
Check for nil host before `match?`.

### DIFF
--- a/lib/http/request.rb
+++ b/lib/http/request.rb
@@ -326,11 +326,9 @@ module HTTP
     # @return [String]
     # @api private
     def default_host_header_value
-      value = PORTS[@scheme] == port ? host : "#{host}:#{port}"
+      raise RequestError, "Invalid host: #{host.inspect}" if host.nil? || host.match?(/\s/)
 
-      raise RequestError, "Invalid host: #{value.inspect}" if value.match?(/\s/)
-
-      value
+      PORTS[@scheme] == port ? host : "#{host}:#{port}"
     end
 
     # Parse and normalize the URI, setting scheme

--- a/test/http/request_test.rb
+++ b/test/http/request_test.rb
@@ -266,6 +266,18 @@ class HTTPRequestTest < Minitest::Test
     assert_includes err.message, "exam ple.com".inspect
   end
 
+  def test_host_header_when_host_is_nil_raises_request_error
+    normalizer = lambda { |uri|
+      u = HTTP::URI.parse(uri)
+      u.host = nil
+      u
+    }
+
+    assert_raises(HTTP::RequestError) do
+      HTTP::Request.new(verb: :get, uri: "http://example.com/", uri_normalizer: normalizer)
+    end
+  end
+
   # User-Agent header
 
   def test_user_agent_header_defaults_to_http_request_user_agent


### PR DESCRIPTION
When host is nil, I get a `NoMethodError: undefined method 'match?' for nil` error instead of a `RequestError`.

Thanks!