### PR TITLE
Fix typos in code comments

### DIFF
--- a/lib/http/features/instrumentation.rb
+++ b/lib/http/features/instrumentation.rb
@@ -14,8 +14,8 @@ module HTTP
     #
     # Emits two events on every request:
     #
-    #  * `start_request.http` before the request is made, so you can log the reqest being started
-    #  * `request.http` after the response is recieved, and contains `start`
+    #  * `start_request.http` before the request is made, so you can log the request being started
+    #  * `request.http` after the response is received, and contains `start`
     #    and `finish` so the duration of the request can be calculated.
     #
     class Instrumentation < Feature

--- a/lib/http/response.rb
+++ b/lib/http/response.rb
@@ -337,9 +337,9 @@ module HTTP
     # @return [HTTP::Request]
     # @api private
     def init_request(request, uri)
-      raise ArgumentError, ":uri is for backwards compatibilty and conflicts with :request" if request && uri
+      raise ArgumentError, ":uri is for backwards compatibility and conflicts with :request" if request && uri
 
-      # For backwards compatibilty
+      # For backwards compatibility
       if uri
         HTTP::Request.new(uri: uri, verb: :get)
       else


### PR DESCRIPTION
Fix three typos in code comments in library source files.

**lib/http/response.rb** (line 340, 342):
- `compatibilty` -> `compatibility` (appears twice)

**lib/http/features/instrumentation.rb** (lines 17-18):
- `reqest` -> `request`
- `recieved` -> `received`

No logic changes, comments only.